### PR TITLE
feat: add yaai-llm crate — LlmClient abstraction with OpenAI, Claude, and Stub backends

### DIFF
--- a/crates/llm/Cargo.toml
+++ b/crates/llm/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "yaai-llm"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+reqwest = { workspace = true }
+tokio = { workspace = true }

--- a/crates/llm/src/claude.rs
+++ b/crates/llm/src/claude.rs
@@ -1,0 +1,120 @@
+//! Anthropic Claude Messages API client.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::{LlmClient, LlmResponse, Message};
+
+const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
+const ANTHROPIC_VERSION: &str = "2023-06-01";
+const DEFAULT_MODEL: &str = "claude-sonnet-4-5";
+/// Anthropic recommends setting max_tokens explicitly; use a generous default.
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+#[derive(Debug, Clone)]
+pub struct ClaudeClient {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl ClaudeClient {
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        let model = model.into();
+        let model = if model.is_empty() {
+            DEFAULT_MODEL.to_string()
+        } else {
+            model
+        };
+        Self {
+            api_key: api_key.into(),
+            model,
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+// ── Anthropic wire types ─────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct MessagesRequest<'a> {
+    model: &'a str,
+    max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    system: Option<&'a str>,
+    messages: &'a [Message],
+}
+
+#[derive(Deserialize)]
+struct MessagesResponse {
+    content: Vec<ContentBlock>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ContentBlock {
+    Text { text: String },
+    ToolUse { name: String, input: serde_json::Value },
+    #[serde(other)]
+    Unknown,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+// grcov-excl-start
+#[async_trait]
+impl LlmClient for ClaudeClient {
+    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
+        debug!(model = %self.model, messages = messages.len(), "calling Claude");
+
+        let body = MessagesRequest {
+            model: &self.model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            system,
+            messages,
+        };
+
+        let response = self
+            .client
+            .post(ANTHROPIC_API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .json(&body)
+            .send()
+            .await
+            .context("sending request to Anthropic")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Anthropic API error ({}): {}", status, body);
+        }
+
+        let resp: MessagesResponse = response
+            .json()
+            .await
+            .context("parsing Anthropic response")?;
+
+        // Prefer tool_use blocks first (same priority as OpenAI implementation).
+        for block in &resp.content {
+            if let ContentBlock::ToolUse { name, input } = block {
+                return Ok(LlmResponse::tool(name.clone(), input.clone()));
+            }
+        }
+
+        // Fall back to the first text block.
+        for block in resp.content {
+            if let ContentBlock::Text { text } = block {
+                return Ok(LlmResponse::text(text));
+            }
+        }
+
+        Ok(LlmResponse {
+            content: None,
+            tool_call: None,
+        })
+    }
+}
+// grcov-excl-stop

--- a/crates/llm/src/claude.rs
+++ b/crates/llm/src/claude.rs
@@ -22,6 +22,16 @@ pub struct ClaudeClient {
 
 impl ClaudeClient {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self::with_client(api_key, model, crate::default_http_client())
+    }
+
+    /// Construct with a caller-supplied [`reqwest::Client`] for full control
+    /// over timeouts, proxies, TLS, etc.
+    pub fn with_client(
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        client: reqwest::Client,
+    ) -> Self {
         let model = model.into();
         let model = if model.is_empty() {
             DEFAULT_MODEL.to_string()
@@ -31,7 +41,7 @@ impl ClaudeClient {
         Self {
             api_key: api_key.into(),
             model,
-            client: reqwest::Client::new(),
+            client,
         }
     }
 }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -1,0 +1,105 @@
+//! LLM client abstraction.
+//!
+//! Defines the [`LlmClient`] trait and provides:
+//! - [`StubClient`]: scripted responses for deterministic testing
+//! - [`OpenAiClient`]: calls the OpenAI chat completions API
+//! - [`ClaudeClient`]: calls the Anthropic Messages API
+
+pub mod claude;
+pub mod openai;
+pub mod stub;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+
+pub use claude::ClaudeClient;
+pub use openai::OpenAiClient;
+pub use stub::StubClient;
+
+/// A message in the conversation history.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Message {
+    pub role: String,
+    pub content: String,
+}
+
+impl Message {
+    pub fn system(content: impl Into<String>) -> Self {
+        Self {
+            role: "system".into(),
+            content: content.into(),
+        }
+    }
+
+    pub fn user(content: impl Into<String>) -> Self {
+        Self {
+            role: "user".into(),
+            content: content.into(),
+        }
+    }
+
+    pub fn assistant(content: impl Into<String>) -> Self {
+        Self {
+            role: "assistant".into(),
+            content: content.into(),
+        }
+    }
+}
+
+/// A tool call emitted by the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ToolCall {
+    pub name: String,
+    pub arguments: serde_json::Value,
+}
+
+/// The LLM's response to a completion request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LlmResponse {
+    /// Free-text content (reasoning, final answer, etc.).
+    pub content: Option<String>,
+    /// Tool call, if the LLM chose to invoke a tool this step.
+    pub tool_call: Option<ToolCall>,
+}
+
+impl LlmResponse {
+    pub fn text(content: impl Into<String>) -> Self {
+        Self {
+            content: Some(content.into()),
+            tool_call: None,
+        }
+    }
+
+    pub fn tool(name: impl Into<String>, arguments: serde_json::Value) -> Self {
+        Self {
+            content: None,
+            tool_call: Some(ToolCall {
+                name: name.into(),
+                arguments,
+            }),
+        }
+    }
+
+    /// True when the response contains text and no tool call — signals loop end.
+    pub fn is_final_answer(&self) -> bool {
+        self.tool_call.is_none() && self.content.is_some()
+    }
+}
+
+/// Core LLM abstraction — send messages, receive a response.
+///
+/// `system` is passed separately so providers that require a dedicated
+/// system field (e.g. Anthropic) can handle it natively, while others
+/// (e.g. OpenAI) can prepend it to the messages array.
+#[async_trait]
+pub trait LlmClient: Send + Sync {
+    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse>;
+}
+
+#[async_trait]
+impl LlmClient for Box<dyn LlmClient> {
+    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
+        (**self).complete(system, messages).await
+    }
+}

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -13,6 +13,16 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
+/// Build a [`reqwest::Client`] with sensible defaults: 10 s connect timeout,
+/// 120 s overall request timeout.
+pub(crate) fn default_http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .timeout(std::time::Duration::from_secs(120))
+        .build()
+        .expect("failed to build reqwest client")
+}
+
 pub use claude::ClaudeClient;
 pub use openai::OpenAiClient;
 pub use stub::StubClient;

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -16,10 +16,20 @@ pub struct OpenAiClient {
 
 impl OpenAiClient {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self::with_client(api_key, model, crate::default_http_client())
+    }
+
+    /// Construct with a caller-supplied [`reqwest::Client`] for full control
+    /// over timeouts, proxies, TLS, etc.
+    pub fn with_client(
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        client: reqwest::Client,
+    ) -> Self {
         Self {
             api_key: api_key.into(),
             model: model.into(),
-            client: reqwest::Client::new(),
+            client,
         }
     }
 }

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -1,0 +1,128 @@
+//! OpenAI chat completions client.
+
+use anyhow::{Context, Result, bail};
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::{LlmClient, LlmResponse, Message};
+
+#[derive(Debug, Clone)]
+pub struct OpenAiClient {
+    api_key: String,
+    model: String,
+    client: reqwest::Client,
+}
+
+impl OpenAiClient {
+    pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
+        Self {
+            api_key: api_key.into(),
+            model: model.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+}
+
+// ── OpenAI wire types ────────────────────────────────────────────────────────
+
+#[derive(Serialize)]
+struct ChatRequest<'a> {
+    model: &'a str,
+    messages: &'a [Message],
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<Choice>,
+}
+
+#[derive(Deserialize)]
+struct Choice {
+    message: ResponseMessage,
+}
+
+#[derive(Deserialize)]
+struct ResponseMessage {
+    content: Option<String>,
+    tool_calls: Option<Vec<OaiToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct OaiToolCall {
+    function: OaiFunction,
+}
+
+#[derive(Deserialize)]
+struct OaiFunction {
+    name: String,
+    /// JSON-encoded string of the arguments object.
+    arguments: String,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+// grcov-excl-start
+#[async_trait]
+impl LlmClient for OpenAiClient {
+    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
+        debug!(model = %self.model, messages = messages.len(), "calling OpenAI");
+
+        // OpenAI expects the system prompt as the first entry in the messages array.
+        let mut full_messages;
+        let messages = if let Some(sys) = system {
+            full_messages = Vec::with_capacity(messages.len() + 1);
+            full_messages.push(Message::system(sys));
+            full_messages.extend_from_slice(messages);
+            full_messages.as_slice()
+        } else {
+            messages
+        };
+
+        let body = ChatRequest {
+            model: &self.model,
+            messages,
+        };
+
+        let response = self
+            .client
+            .post("https://api.openai.com/v1/chat/completions")
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("sending request to OpenAI")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("OpenAI API error ({}): {}", status, body);
+        }
+
+        let resp: ChatResponse = response
+            .json()
+            .await
+            .context("parsing OpenAI response")?;
+
+        let msg = resp
+            .choices
+            .into_iter()
+            .next()
+            .context("no choices in OpenAI response")?
+            .message;
+
+        if let Some(tool_calls) = msg.tool_calls {
+            if let Some(tc) = tool_calls.into_iter().next() {
+                let args: serde_json::Value = serde_json::from_str(&tc.function.arguments)
+                    .context("parsing tool call arguments")?;
+                return Ok(LlmResponse::tool(tc.function.name, args));
+            }
+        }
+
+        Ok(LlmResponse {
+            content: msg.content,
+            tool_call: None,
+        })
+    }
+}
+// grcov-excl-stop

--- a/crates/llm/src/stub.rs
+++ b/crates/llm/src/stub.rs
@@ -4,10 +4,9 @@
 //! It returns an error if the script is exhausted, which signals that the
 //! agent ran more steps than the test anticipated.
 
-use std::sync::Mutex;
-
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use tokio::sync::Mutex;
 
 use crate::{LlmClient, LlmResponse, Message};
 
@@ -28,8 +27,10 @@ impl StubClient {
 #[async_trait]
 impl LlmClient for StubClient {
     async fn complete(&self, _system: Option<&str>, _messages: &[Message]) -> Result<LlmResponse> {
-        self.script.lock().unwrap().pop().ok_or_else(|| {
-            anyhow!("StubClient script exhausted — agent ran more steps than expected")
-        })
+        self.script
+            .lock()
+            .await
+            .pop()
+            .ok_or_else(|| anyhow!("StubClient script exhausted — agent ran more steps than expected"))
     }
 }

--- a/crates/llm/src/stub.rs
+++ b/crates/llm/src/stub.rs
@@ -1,0 +1,35 @@
+//! A scripted LLM stub for deterministic testing.
+//!
+//! [`StubClient`] returns pre-scripted [`LlmResponse`]s in order.
+//! It returns an error if the script is exhausted, which signals that the
+//! agent ran more steps than the test anticipated.
+
+use std::sync::Mutex;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+
+use crate::{LlmClient, LlmResponse, Message};
+
+pub struct StubClient {
+    script: Mutex<Vec<LlmResponse>>,
+}
+
+impl StubClient {
+    /// Create a stub with a sequence of responses (first element = first returned).
+    pub fn new(mut responses: Vec<LlmResponse>) -> Self {
+        responses.reverse(); // pop() from the end returns in original order
+        Self {
+            script: Mutex::new(responses),
+        }
+    }
+}
+
+#[async_trait]
+impl LlmClient for StubClient {
+    async fn complete(&self, _system: Option<&str>, _messages: &[Message]) -> Result<LlmResponse> {
+        self.script.lock().unwrap().pop().ok_or_else(|| {
+            anyhow!("StubClient script exhausted — agent ran more steps than expected")
+        })
+    }
+}

--- a/crates/llm/tests/stub_tests.rs
+++ b/crates/llm/tests/stub_tests.rs
@@ -1,0 +1,168 @@
+use yaai_llm::{LlmClient, LlmResponse, Message, StubClient, ToolCall};
+
+#[tokio::test]
+async fn stub_returns_responses_in_order() {
+    let client = StubClient::new(vec![
+        LlmResponse::text("first"),
+        LlmResponse::text("second"),
+        LlmResponse::text("third"),
+    ]);
+    let msgs = vec![Message::user("test")];
+
+    let r1 = client.complete(None, &msgs).await.unwrap();
+    let r2 = client.complete(None, &msgs).await.unwrap();
+    let r3 = client.complete(None, &msgs).await.unwrap();
+
+    assert_eq!(r1.content.as_deref(), Some("first"));
+    assert_eq!(r2.content.as_deref(), Some("second"));
+    assert_eq!(r3.content.as_deref(), Some("third"));
+}
+
+#[tokio::test]
+async fn stub_errors_when_exhausted() {
+    let client = StubClient::new(vec![LlmResponse::text("only one")]);
+    let msgs = vec![Message::user("test")];
+
+    client.complete(None, &msgs).await.unwrap();
+    let err = client.complete(None, &msgs).await;
+    assert!(err.is_err());
+    assert!(err.unwrap_err().to_string().contains("exhausted"));
+}
+
+#[test]
+fn is_final_answer_when_no_tool_call() {
+    assert!(LlmResponse::text("done").is_final_answer());
+}
+
+#[test]
+fn not_final_when_tool_call_present() {
+    let r = LlmResponse::tool("calculator", serde_json::json!({"expression": "1+1"}));
+    assert!(!r.is_final_answer());
+}
+
+#[test]
+fn message_system_sets_role() {
+    let m = Message::system("you are an agent");
+    assert_eq!(m.role, "system");
+    assert_eq!(m.content, "you are an agent");
+}
+
+#[test]
+fn message_user_sets_role() {
+    let m = Message::user("hello");
+    assert_eq!(m.role, "user");
+    assert_eq!(m.content, "hello");
+}
+
+#[test]
+fn message_assistant_sets_role() {
+    let m = Message::assistant("hi there");
+    assert_eq!(m.role, "assistant");
+    assert_eq!(m.content, "hi there");
+}
+
+#[test]
+fn llm_response_text_has_content_no_tool_call() {
+    let r = LlmResponse::text("answer");
+    assert_eq!(r.content.as_deref(), Some("answer"));
+    assert!(r.tool_call.is_none());
+}
+
+#[test]
+fn llm_response_tool_has_tool_call_no_content() {
+    let args = serde_json::json!({"x": 1});
+    let r = LlmResponse::tool("my_tool", args.clone());
+    assert!(r.content.is_none());
+    let tc = r.tool_call.unwrap();
+    assert_eq!(tc.name, "my_tool");
+    assert_eq!(tc.arguments, args);
+}
+
+#[test]
+fn llm_response_neither_is_not_final() {
+    let r = LlmResponse {
+        content: None,
+        tool_call: None,
+    };
+    assert!(!r.is_final_answer());
+}
+
+#[test]
+fn tool_call_equality() {
+    let a = ToolCall {
+        name: "calc".to_string(),
+        arguments: serde_json::json!({"expression": "1+1"}),
+    };
+    let b = ToolCall {
+        name: "calc".to_string(),
+        arguments: serde_json::json!({"expression": "1+1"}),
+    };
+    assert_eq!(a, b);
+}
+
+#[tokio::test]
+async fn box_dyn_client_delegates() {
+    let inner = StubClient::new(vec![LlmResponse::text("delegated")]);
+    let boxed: Box<dyn LlmClient> = Box::new(inner);
+    let result = boxed.complete(None, &[Message::user("test")]).await.unwrap();
+    assert_eq!(result.content.as_deref(), Some("delegated"));
+}
+
+#[test]
+fn message_serde_round_trip() {
+    let m = Message::system("be helpful");
+    let json = serde_json::to_string(&m).unwrap();
+    let m2: Message = serde_json::from_str(&json).unwrap();
+    assert_eq!(m2.role, "system");
+    assert_eq!(m2.content, "be helpful");
+}
+
+#[test]
+fn llm_response_text_serde_round_trip() {
+    let r = LlmResponse::text("the answer");
+    let json = serde_json::to_string(&r).unwrap();
+    let r2: LlmResponse = serde_json::from_str(&json).unwrap();
+    assert_eq!(r2.content.as_deref(), Some("the answer"));
+    assert!(r2.tool_call.is_none());
+}
+
+#[test]
+fn llm_response_tool_serde_round_trip() {
+    let r = LlmResponse::tool("calc", serde_json::json!({"expr": "1+1"}));
+    let json = serde_json::to_string(&r).unwrap();
+    let r2: LlmResponse = serde_json::from_str(&json).unwrap();
+    let tc = r2.tool_call.unwrap();
+    assert_eq!(tc.name, "calc");
+}
+
+#[test]
+fn tool_call_serde_round_trip() {
+    let tc = ToolCall {
+        name: "my_tool".to_string(),
+        arguments: serde_json::json!({"x": 42}),
+    };
+    let json = serde_json::to_string(&tc).unwrap();
+    let tc2: ToolCall = serde_json::from_str(&json).unwrap();
+    assert_eq!(tc2.name, "my_tool");
+    assert_eq!(tc2.arguments["x"], 42);
+}
+
+#[test]
+fn claude_client_new_empty_model_uses_default() {
+    use yaai_llm::ClaudeClient;
+    // Empty model string should fall back to the built-in default — just verify construction succeeds
+    let _ = ClaudeClient::new("test-api-key", "");
+}
+
+#[test]
+fn claude_client_new_explicit_model() {
+    use yaai_llm::ClaudeClient;
+    let _ = ClaudeClient::new("test-api-key", "claude-3-opus");
+}
+
+#[test]
+fn openai_client_new() {
+    use yaai_llm::OpenAiClient;
+    let _ = OpenAiClient::new("test-api-key", "gpt-4o");
+}
+


### PR DESCRIPTION
## Summary

Introduces the `yaai-llm` crate, which provides a thin, provider-agnostic interface for sending a prompt to an LLM and receiving a response.

## What's included

### `LlmClient` trait (`src/lib.rs`)
```rust
#[async_trait]
pub trait LlmClient: Send + Sync {
    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse>;
}
```
The single method accepts an optional system prompt and a slice of conversation `Message`s and returns an `LlmResponse`.

### Core types
| Type | Purpose |
|------|---------|
| `Message` | Typed conversation turn with `role` + `content`; constructors `::system`, `::user`, `::assistant` |
| `LlmResponse` | Carries optional `content: String` (text answer) and/or `tool_call: ToolCall` |
| `ToolCall` | Name + JSON arguments of a requested tool invocation |

`LlmResponse::is_final_answer()` returns `true` when the response contains text and no tool call — used by the agent loop to detect termination.

### Backends
- **`OpenAiClient`** (`src/openai.rs`) — POST `/v1/chat/completions`; injects the system prompt as the first message entry as required by the OpenAI API.
- **`ClaudeClient`** (`src/claude.rs`) — Anthropic Messages API (`/v1/messages`); passes the system prompt via the dedicated top-level `system` field; defaults to `claude-sonnet-4-5` when no model is specified.
- **`StubClient`** (`src/stub.rs`) — returns a pre-scripted sequence of `LlmResponse`s in order; errors with a clear message if the script is exhausted. Intended for all agent-level tests so no real API calls are made.

### Tests (`tests/stub_tests.rs`)
16 tests covering:
- `StubClient` ordering and exhaustion behaviour
- `is_final_answer` edge cases
- `Message` and `LlmResponse` serde round-trips
- `Box<dyn LlmClient>` delegation
- `ClaudeClient` / `OpenAiClient` construction