### PR TITLE
feat: add yaai-tracer crate — structured JSON trace emitter

### DIFF
--- a/crates/tracer/Cargo.toml
+++ b/crates/tracer/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "yaai-tracer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+chrono = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+tokio = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/tracer/Cargo.toml
+++ b/crates/tracer/Cargo.toml
@@ -15,3 +15,4 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }

--- a/crates/tracer/src/lib.rs
+++ b/crates/tracer/src/lib.rs
@@ -1,0 +1,195 @@
+//! Structured tracing for agent runs.
+//!
+//! Each agent run emits a sequence of [`TraceEvent`]s written to
+//! `<output_dir>/<run_id>.ndjson` as newline-delimited JSON. Events are
+//! written to disk immediately as they are recorded, so the file can be
+//! tailed while the agent is running.
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tokio::sync::{mpsc, oneshot};
+use uuid::Uuid;
+
+/// The kind of event recorded in a trace.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventKind {
+    /// The prompt sent to the LLM at a given step.
+    Prompt,
+    /// The LLM decided to call a tool.
+    ToolCall,
+    /// The tool returned a result.
+    ToolResult,
+    /// The LLM produced a reasoning/decision step.
+    Decision,
+    /// The agent produced a final answer and the loop ended.
+    FinalAnswer,
+    /// An error occurred (tool failure, LLM error, etc.).
+    Error,
+}
+
+/// A single event in an agent run trace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceEvent {
+    pub run_id: Uuid,
+    pub agent_id: String,
+    pub step: u32,
+    pub kind: EventKind,
+    pub payload: serde_json::Value,
+    pub timestamp: DateTime<Utc>,
+}
+
+impl TraceEvent {
+    pub fn new(
+        run_id: Uuid,
+        agent_id: impl Into<String>,
+        step: u32,
+        kind: EventKind,
+        payload: impl Serialize,
+    ) -> Result<Self> {
+        Ok(Self {
+            run_id,
+            agent_id: agent_id.into(),
+            step,
+            kind,
+            payload: serde_json::to_value(payload)?,
+            timestamp: Utc::now(),
+        })
+    }
+}
+
+enum WriterMsg {
+    Event(TraceEvent),
+    /// Flush OS buffers; ack when done.
+    Flush(oneshot::Sender<()>),
+}
+
+/// Streams trace events to `<output_dir>/<run_id>.ndjson` as they are recorded.
+///
+/// Events are sent to a background writer task over an in-process channel, so
+/// `record` and `emit` are non-blocking. Call `flush` to wait for pending writes
+/// to reach disk, and `close` to shut down cleanly at the end of a run.
+#[derive(Debug)]
+pub struct Tracer {
+    run_id: Uuid,
+    tx: mpsc::UnboundedSender<WriterMsg>,
+    handle: tokio::task::JoinHandle<Result<()>>,
+}
+
+impl Tracer {
+    /// Create a new tracer and start the background writer task.
+    ///
+    /// Events are written to `<output_dir>/<run_id>.ndjson`. The directory is
+    /// created if it does not exist.
+    pub fn new(run_id: Uuid, output_dir: impl Into<PathBuf>) -> Result<Self> {
+        let output_dir = output_dir.into();
+        std::fs::create_dir_all(&output_dir).context("creating traces output dir")?;
+
+        let path = output_dir.join(format!("{run_id}.ndjson"));
+        let (tx, rx) = mpsc::unbounded_channel::<WriterMsg>();
+
+        let handle = tokio::spawn(writer_task(path, rx));
+
+        Ok(Self { run_id, tx, handle })
+    }
+
+    /// Record an event. Non-blocking — the event is queued for the writer task.
+    pub fn record(&self, event: TraceEvent) {
+        tracing::debug!(
+            run_id = %event.run_id,
+            step = event.step,
+            kind = ?event.kind,
+            "trace event"
+        );
+        // Only fails if the writer task has exited (e.g. panicked).
+        let _ = self.tx.send(WriterMsg::Event(event));
+    }
+
+    /// Convenience: build and record an event for this run.
+    pub fn emit(
+        &self,
+        agent_id: impl Into<String>,
+        step: u32,
+        kind: EventKind,
+        payload: impl Serialize,
+    ) -> Result<()> {
+        let event = TraceEvent::new(self.run_id, agent_id, step, kind, payload)?;
+        self.record(event);
+        Ok(())
+    }
+
+    /// The run ID for this tracer.
+    pub fn run_id(&self) -> Uuid {
+        self.run_id
+    }
+
+    /// Wait until all queued events have been written and flushed to the OS.
+    pub async fn flush(&self) -> Result<()> {
+        let (ack_tx, ack_rx) = oneshot::channel();
+        let _ = self.tx.send(WriterMsg::Flush(ack_tx));
+        ack_rx.await.context("tracer writer task exited before flush")
+    }
+
+    /// Flush all pending events and shut down the writer task.
+    ///
+    /// Must be called at the end of a run to ensure all events reach disk.
+    pub async fn close(self) -> Result<()> {
+        drop(self.tx);
+        self.handle
+            .await
+            .context("tracer writer task panicked")?
+    }
+}
+
+async fn writer_task(
+    path: PathBuf,
+    mut rx: mpsc::UnboundedReceiver<WriterMsg>,
+) -> Result<()> {
+    let mut file = tokio::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .await
+        .with_context(|| format!("opening trace file {}", path.display()))?;
+
+    while let Some(msg) = rx.recv().await {
+        match msg {
+            WriterMsg::Event(event) => {
+                let mut line = serde_json::to_string(&event)
+                    .context("serialising trace event")?;
+                line.push('\n');
+                file.write_all(line.as_bytes())
+                    .await
+                    .with_context(|| format!("writing to {}", path.display()))?;
+            }
+            WriterMsg::Flush(ack) => {
+                file.flush()
+                    .await
+                    .with_context(|| format!("flushing {}", path.display()))?;
+                let _ = ack.send(());
+            }
+        }
+    }
+
+    // Sender dropped (close() called) — flush and exit cleanly.
+    file.flush().await.context("final flush")?;
+    tracing::info!(path = %path.display(), "trace closed");
+    Ok(())
+}
+
+/// Initialise a `tracing-subscriber` for the process (JSON or pretty).
+pub fn init_tracing(json: bool) {
+    use tracing_subscriber::{fmt, EnvFilter};
+
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+    if json {
+        fmt().json().with_env_filter(filter).init();
+    } else {
+        fmt().pretty().with_env_filter(filter).init();
+    }
+}

--- a/crates/tracer/src/lib.rs
+++ b/crates/tracer/src/lib.rs
@@ -2,8 +2,9 @@
 //!
 //! Each agent run emits a sequence of [`TraceEvent`]s written to
 //! `<output_dir>/<run_id>.ndjson` as newline-delimited JSON. Events are
-//! written to disk immediately as they are recorded, so the file can be
-//! tailed while the agent is running.
+//! written asynchronously via a background task, so the file can be tailed
+//! while the agent is running. Call [`Tracer::flush`] to wait for all queued
+//! events to be written.
 
 use std::path::PathBuf;
 
@@ -85,6 +86,10 @@ impl Tracer {
     ///
     /// Events are written to `<output_dir>/<run_id>.ndjson`. The directory is
     /// created if it does not exist.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called outside of a Tokio runtime context.
     pub fn new(run_id: Uuid, output_dir: impl Into<PathBuf>) -> Result<Self> {
         let output_dir = output_dir.into();
         std::fs::create_dir_all(&output_dir).context("creating traces output dir")?;
@@ -106,7 +111,13 @@ impl Tracer {
             "trace event"
         );
         // Only fails if the writer task has exited (e.g. panicked).
-        let _ = self.tx.send(WriterMsg::Event(event));
+        if let Err(err) = self.tx.send(WriterMsg::Event(event)) {
+            tracing::error!(
+                run_id = %self.run_id,
+                error = ?err,
+                "tracer writer task has exited; dropping trace event"
+            );
+        }
     }
 
     /// Convenience: build and record an event for this run.
@@ -127,7 +138,11 @@ impl Tracer {
         self.run_id
     }
 
-    /// Wait until all queued events have been written and flushed to the OS.
+    /// Wait until all queued events have been written to the OS write buffer.
+    ///
+    /// This is a write-barrier: it guarantees that all events emitted before
+    /// this call have been processed by the writer task and handed to the OS.
+    /// It does **not** guarantee durability (no `fsync`/`sync_data` is issued).
     pub async fn flush(&self) -> Result<()> {
         let (ack_tx, ack_rx) = oneshot::channel();
         let _ = self.tx.send(WriterMsg::Flush(ack_tx));
@@ -182,14 +197,17 @@ async fn writer_task(
 }
 
 /// Initialise a `tracing-subscriber` for the process (JSON or pretty).
-pub fn init_tracing(json: bool) {
+///
+/// Returns an error if a global subscriber has already been set.
+pub fn init_tracing(json: bool) -> Result<()> {
     use tracing_subscriber::{fmt, EnvFilter};
 
     let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     if json {
-        fmt().json().with_env_filter(filter).init();
+        fmt().json().with_env_filter(filter).try_init()
     } else {
-        fmt().pretty().with_env_filter(filter).init();
+        fmt().pretty().with_env_filter(filter).try_init()
     }
+    .map_err(|e| anyhow::anyhow!(e))
 }

--- a/crates/tracer/tests/tracer_tests.rs
+++ b/crates/tracer/tests/tracer_tests.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use uuid::Uuid;
 use yaai_tracer::{EventKind, TraceEvent, Tracer};
 
@@ -12,7 +14,8 @@ fn parse_ndjson(content: &str) -> Vec<serde_json::Value> {
 #[tokio::test]
 async fn records_events_in_order() {
     let run_id = Uuid::new_v4();
-    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tmp = tempfile::tempdir().unwrap();
+    let dir: PathBuf = tmp.path().to_path_buf();
     let tracer = Tracer::new(run_id, &dir).unwrap();
 
     tracer.emit("agent-a", 0, EventKind::Prompt, "hello").unwrap();
@@ -21,35 +24,31 @@ async fn records_events_in_order() {
 
     tracer.close().await.unwrap();
 
-    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    let content = tokio::fs::read_to_string(dir.join(format!("{run_id}.ndjson"))).await.unwrap();
     let events = parse_ndjson(&content);
     assert_eq!(events.len(), 3);
     assert_eq!(events[0]["kind"], "prompt");
     assert_eq!(events[1]["kind"], "tool_call");
     assert_eq!(events[2]["kind"], "final_answer");
     assert!(events.iter().all(|e| e["run_id"] == run_id.to_string()));
-
-    tokio::fs::remove_dir_all(&dir).await.unwrap();
 }
 
 #[tokio::test]
 async fn flush_writes_ndjson_file() {
     let run_id = Uuid::new_v4();
-    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tmp = tempfile::tempdir().unwrap();
+    let dir: PathBuf = tmp.path().to_path_buf();
     let tracer = Tracer::new(run_id, &dir).unwrap();
 
     tracer.emit("agent-a", 0, EventKind::FinalAnswer, "result").unwrap();
     tracer.flush().await.unwrap();
 
-    // File is readable mid-run (before close).
-    let path = format!("{dir}/{run_id}.ndjson");
-    let content = tokio::fs::read_to_string(&path).await.unwrap();
+    let content = tokio::fs::read_to_string(dir.join(format!("{run_id}.ndjson"))).await.unwrap();
     let events = parse_ndjson(&content);
     assert_eq!(events.len(), 1);
     assert_eq!(events[0]["kind"], "final_answer");
 
     tracer.close().await.unwrap();
-    tokio::fs::remove_dir_all(&dir).await.unwrap();
 }
 
 #[tokio::test]
@@ -57,32 +56,30 @@ async fn events_visible_before_close() {
     // Verifies that flush() makes events readable without closing the tracer,
     // which is the key property for tailing a live run.
     let run_id = Uuid::new_v4();
-    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tmp = tempfile::tempdir().unwrap();
+    let dir: PathBuf = tmp.path().to_path_buf();
     let tracer = Tracer::new(run_id, &dir).unwrap();
 
     tracer.emit("agent-a", 0, EventKind::Prompt, "step one").unwrap();
     tracer.flush().await.unwrap();
 
-    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    let content = tokio::fs::read_to_string(dir.join(format!("{run_id}.ndjson"))).await.unwrap();
     assert_eq!(parse_ndjson(&content).len(), 1);
 
     tracer.emit("agent-a", 1, EventKind::FinalAnswer, "step two").unwrap();
     tracer.close().await.unwrap();
 
-    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    let content = tokio::fs::read_to_string(dir.join(format!("{run_id}.ndjson"))).await.unwrap();
     assert_eq!(parse_ndjson(&content).len(), 2);
-
-    tokio::fs::remove_dir_all(&dir).await.unwrap();
 }
 
 #[tokio::test]
 async fn run_id_is_stable() {
     let id = Uuid::new_v4();
-    let dir = format!("/tmp/yaai-test-traces-{id}");
-    let tracer = Tracer::new(id, &dir).unwrap();
+    let tmp = tempfile::tempdir().unwrap();
+    let tracer = Tracer::new(id, tmp.path()).unwrap();
     assert_eq!(tracer.run_id(), id);
     tracer.close().await.unwrap();
-    tokio::fs::remove_dir_all(&dir).await.unwrap();
 }
 
 #[test]
@@ -115,17 +112,16 @@ fn trace_event_new_fields() {
 #[tokio::test]
 async fn record_directly() {
     let run_id = Uuid::new_v4();
-    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tmp = tempfile::tempdir().unwrap();
+    let dir: PathBuf = tmp.path().to_path_buf();
     let tracer = Tracer::new(run_id, &dir).unwrap();
 
     let event = TraceEvent::new(run_id, "agent-x", 0, EventKind::ToolResult, "result").unwrap();
     tracer.record(event);
     tracer.close().await.unwrap();
 
-    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    let content = tokio::fs::read_to_string(dir.join(format!("{run_id}.ndjson"))).await.unwrap();
     let events = parse_ndjson(&content);
     assert_eq!(events.len(), 1);
     assert_eq!(events[0]["kind"], "tool_result");
-
-    tokio::fs::remove_dir_all(&dir).await.unwrap();
 }

--- a/crates/tracer/tests/tracer_tests.rs
+++ b/crates/tracer/tests/tracer_tests.rs
@@ -1,0 +1,131 @@
+use uuid::Uuid;
+use yaai_tracer::{EventKind, TraceEvent, Tracer};
+
+fn parse_ndjson(content: &str) -> Vec<serde_json::Value> {
+    content
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| serde_json::from_str(l).unwrap())
+        .collect()
+}
+
+#[tokio::test]
+async fn records_events_in_order() {
+    let run_id = Uuid::new_v4();
+    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tracer = Tracer::new(run_id, &dir).unwrap();
+
+    tracer.emit("agent-a", 0, EventKind::Prompt, "hello").unwrap();
+    tracer.emit("agent-a", 1, EventKind::ToolCall, "search").unwrap();
+    tracer.emit("agent-a", 2, EventKind::FinalAnswer, "done").unwrap();
+
+    tracer.close().await.unwrap();
+
+    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    let events = parse_ndjson(&content);
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0]["kind"], "prompt");
+    assert_eq!(events[1]["kind"], "tool_call");
+    assert_eq!(events[2]["kind"], "final_answer");
+    assert!(events.iter().all(|e| e["run_id"] == run_id.to_string()));
+
+    tokio::fs::remove_dir_all(&dir).await.unwrap();
+}
+
+#[tokio::test]
+async fn flush_writes_ndjson_file() {
+    let run_id = Uuid::new_v4();
+    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tracer = Tracer::new(run_id, &dir).unwrap();
+
+    tracer.emit("agent-a", 0, EventKind::FinalAnswer, "result").unwrap();
+    tracer.flush().await.unwrap();
+
+    // File is readable mid-run (before close).
+    let path = format!("{dir}/{run_id}.ndjson");
+    let content = tokio::fs::read_to_string(&path).await.unwrap();
+    let events = parse_ndjson(&content);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["kind"], "final_answer");
+
+    tracer.close().await.unwrap();
+    tokio::fs::remove_dir_all(&dir).await.unwrap();
+}
+
+#[tokio::test]
+async fn events_visible_before_close() {
+    // Verifies that flush() makes events readable without closing the tracer,
+    // which is the key property for tailing a live run.
+    let run_id = Uuid::new_v4();
+    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tracer = Tracer::new(run_id, &dir).unwrap();
+
+    tracer.emit("agent-a", 0, EventKind::Prompt, "step one").unwrap();
+    tracer.flush().await.unwrap();
+
+    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    assert_eq!(parse_ndjson(&content).len(), 1);
+
+    tracer.emit("agent-a", 1, EventKind::FinalAnswer, "step two").unwrap();
+    tracer.close().await.unwrap();
+
+    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    assert_eq!(parse_ndjson(&content).len(), 2);
+
+    tokio::fs::remove_dir_all(&dir).await.unwrap();
+}
+
+#[tokio::test]
+async fn run_id_is_stable() {
+    let id = Uuid::new_v4();
+    let dir = format!("/tmp/yaai-test-traces-{id}");
+    let tracer = Tracer::new(id, &dir).unwrap();
+    assert_eq!(tracer.run_id(), id);
+    tracer.close().await.unwrap();
+    tokio::fs::remove_dir_all(&dir).await.unwrap();
+}
+
+#[test]
+fn all_event_kinds_serialize() {
+    let cases = [
+        (EventKind::Prompt, "prompt"),
+        (EventKind::ToolCall, "tool_call"),
+        (EventKind::ToolResult, "tool_result"),
+        (EventKind::Decision, "decision"),
+        (EventKind::FinalAnswer, "final_answer"),
+        (EventKind::Error, "error"),
+    ];
+    for (kind, expected) in cases {
+        let json = serde_json::to_string(&kind).unwrap();
+        assert_eq!(json, format!("\"{}\"", expected), "kind {:?} wrong", kind);
+    }
+}
+
+#[test]
+fn trace_event_new_fields() {
+    let run_id = Uuid::new_v4();
+    let event = TraceEvent::new(run_id, "my-agent", 3, EventKind::Decision, "thinking").unwrap();
+    assert_eq!(event.run_id, run_id);
+    assert_eq!(event.agent_id, "my-agent");
+    assert_eq!(event.step, 3);
+    assert_eq!(event.kind, EventKind::Decision);
+    assert_eq!(event.payload, serde_json::json!("thinking"));
+}
+
+#[tokio::test]
+async fn record_directly() {
+    let run_id = Uuid::new_v4();
+    let dir = format!("/tmp/yaai-test-traces-{run_id}");
+    let tracer = Tracer::new(run_id, &dir).unwrap();
+
+    let event = TraceEvent::new(run_id, "agent-x", 0, EventKind::ToolResult, "result").unwrap();
+    tracer.record(event);
+    tracer.close().await.unwrap();
+
+    let content = tokio::fs::read_to_string(format!("{dir}/{run_id}.ndjson")).await.unwrap();
+    let events = parse_ndjson(&content);
+    assert_eq!(events.len(), 1);
+    assert_eq!(events[0]["kind"], "tool_result");
+
+    tokio::fs::remove_dir_all(&dir).await.unwrap();
+}


### PR DESCRIPTION
## Summary

- Adds the `yaai-tracer` crate implementing structured NDJSON tracing for agent runs
- `Tracer` streams `TraceEvent`s to `<output_dir>/<run_id>.ndjson` via a background async writer task, making files tail-able mid-run
- Includes `flush`/`close` lifecycle methods and integration tests covering event ordering, mid-run visibility, all `EventKind` serialisations, and direct `record` usage