### PR TITLE
feat: implement agent execution loop (ReAct pattern)

### DIFF
--- a/crates/agent-loop/Cargo.toml
+++ b/crates/agent-loop/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "yaai-agent-loop"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+yaai-llm = { path = "../llm" }
+yaai-memory = { path = "../memory" }
+yaai-tools = { path = "../tools" }
+yaai-tracer = { path = "../tracer" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -1,0 +1,178 @@
+//! Agent execution loop — the ReAct pattern (observe → think → act).
+//!
+//! [`AgentRunner`] drives one agent through its loop until the LLM produces a
+//! final answer or `max_steps` is reached.
+
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use tracing::{info, warn};
+use uuid::Uuid;
+use yaai_llm::{LlmClient, Message};
+use yaai_memory::{Role, SessionMemory};
+use yaai_tools::ToolRegistry;
+use yaai_tracer::{EventKind, Tracer};
+
+/// Configuration for a single agent instance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentConfig {
+    /// Unique identifier (used in traces and logs).
+    pub id: String,
+    /// System prompt that frames the agent's role and available tools.
+    pub system_prompt: String,
+    /// Maximum loop iterations before the run is aborted with an error.
+    pub max_steps: u32,
+}
+
+/// The outcome of a completed agent run.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentResult {
+    pub run_id: Uuid,
+    pub agent_id: String,
+    /// The final text answer produced by the agent.
+    pub answer: String,
+    /// Number of loop iterations consumed.
+    pub steps_taken: u32,
+}
+
+/// Drives an agent through its ReAct execution loop.
+pub struct AgentRunner<'a> {
+    config: &'a AgentConfig,
+    llm: &'a dyn LlmClient,
+    tools: &'a ToolRegistry,
+    tracer: &'a Tracer,
+    memory: &'a mut SessionMemory,
+}
+
+impl<'a> AgentRunner<'a> {
+    pub fn new(
+        config: &'a AgentConfig,
+        llm: &'a dyn LlmClient,
+        tools: &'a ToolRegistry,
+        tracer: &'a Tracer,
+        memory: &'a mut SessionMemory,
+    ) -> Self {
+        Self {
+            config,
+            llm,
+            tools,
+            tracer,
+            memory,
+        }
+    }
+
+    /// Run the agent loop on the given task, returning the final answer.
+    pub async fn run(&mut self, task: impl Into<String>) -> Result<AgentResult> {
+        let task = task.into();
+        let run_id = self.tracer.run_id();
+
+        info!(agent = %self.config.id, %run_id, %task, "agent starting");
+
+        self.memory.add(Role::User, &task);
+
+        for step in 0..self.config.max_steps {
+            let messages: Vec<Message> = self
+                .memory
+                .entries()
+                .iter()
+                .map(|e| Message {
+                    // Role::Tool has no direct equivalent in the current Message format
+                    // (which lacks tool_call_id), so tool observations are surfaced to
+                    // the LLM as user messages to maintain API compatibility.
+                    role: match &e.role {
+                        Role::Tool => "user".to_string(),
+                        other => other.to_string(),
+                    },
+                    content: e.content.clone(),
+                })
+                .collect();
+
+            self.tracer.emit(
+                &self.config.id,
+                step,
+                EventKind::Prompt,
+                serde_json::json!({ "message_count": messages.len() }),
+            )?;
+
+            let response = self
+                .llm
+                .complete(Some(&self.config.system_prompt), &messages)
+                .await?;
+
+            if response.content.is_none() && response.tool_call.is_none() {
+                bail!(
+                    "agent '{}' received an empty LLM response at step {}",
+                    self.config.id,
+                    step
+                );
+            }
+
+            if let Some(ref text) = response.content {
+                self.tracer
+                    .emit(&self.config.id, step, EventKind::Decision, text)?;
+                self.memory.add(Role::Assistant, text);
+            }
+
+            if let Some(tc) = &response.tool_call {
+                info!(agent = %self.config.id, tool = %tc.name, step, "tool call");
+
+                self.tracer.emit(
+                    &self.config.id,
+                    step,
+                    EventKind::ToolCall,
+                    serde_json::json!({ "tool": tc.name, "args": tc.arguments }),
+                )?;
+
+                let observation = match self.tools.dispatch(&tc.name, tc.arguments.clone()).await {
+                    Ok(result) => {
+                        self.tracer
+                            .emit(&self.config.id, step, EventKind::ToolResult, &result)?;
+                        result.to_string()
+                    }
+                    Err(e) => {
+                        let msg = format!("Tool error: {e}");
+                        self.tracer.emit(
+                            &self.config.id,
+                            step,
+                            EventKind::Error,
+                            serde_json::json!({ "error": &msg }),
+                        )?;
+                        warn!(agent = %self.config.id, error = %e, "tool execution failed");
+                        msg
+                    }
+                };
+
+                self.memory.add(
+                    Role::Tool,
+                    format!("Tool '{}' returned: {}", tc.name, observation),
+                );
+            } else if response.is_final_answer() {
+                let answer = response.content.unwrap_or_default();
+                info!(agent = %self.config.id, step, "final answer");
+
+                self.tracer
+                    .emit(&self.config.id, step, EventKind::FinalAnswer, &answer)?;
+
+                self.tracer.flush().await?;
+
+                return Ok(AgentResult {
+                    run_id,
+                    agent_id: self.config.id.clone(),
+                    answer,
+                    steps_taken: step + 1,
+                });
+            }
+        }
+
+        warn!(
+            agent = %self.config.id,
+            max = self.config.max_steps,
+            "max steps reached without final answer"
+        );
+        self.tracer.flush().await?;
+        bail!(
+            "agent '{}' reached max_steps ({}) without a final answer",
+            self.config.id,
+            self.config.max_steps
+        );
+    }
+}

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -61,6 +61,10 @@ impl<'a> AgentRunner<'a> {
     }
 
     /// Run the agent loop on the given task, returning the final answer.
+    ///
+    /// The caller is responsible for calling [`Tracer::close`] on the tracer
+    /// after this method returns (success or error) to shut down the background
+    /// writer task cleanly.
     pub async fn run(&mut self, task: impl Into<String>) -> Result<AgentResult> {
         let task = task.into();
         let run_id = self.tracer.run_id();
@@ -99,11 +103,19 @@ impl<'a> AgentRunner<'a> {
                 .await?;
 
             if response.content.is_none() && response.tool_call.is_none() {
-                bail!(
+                let msg = format!(
                     "agent '{}' received an empty LLM response at step {}",
                     self.config.id,
                     step
                 );
+                self.tracer.emit(
+                    &self.config.id,
+                    step,
+                    EventKind::Error,
+                    serde_json::json!({ "error": &msg }),
+                )?;
+                self.tracer.flush().await?;
+                bail!(msg);
             }
 
             if let Some(ref text) = response.content {

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -42,6 +42,7 @@ async fn produces_final_answer_without_tools() {
 
     assert_eq!(result.answer, "The answer is 42.");
     assert_eq!(result.steps_taken, 1);
+    tr.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -63,6 +64,7 @@ async fn calls_tool_then_answers() {
 
     assert_eq!(result.answer, "The answer is 42.");
     assert_eq!(result.steps_taken, 2);
+    tr.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -84,6 +86,7 @@ async fn respects_max_steps() {
         .unwrap_err();
 
     assert!(err.to_string().contains("max_steps"));
+    tr.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -108,6 +111,7 @@ async fn trace_has_correct_event_sequence() {
     // 2 steps: one tool call + one final answer
     assert_eq!(result.steps_taken, 2);
     assert_eq!(result.answer, "Result is done.");
+    tr.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -129,6 +133,7 @@ async fn memory_accumulates_across_steps() {
 
     // user task + tool result observation + final assistant = at least 3
     assert!(mem.len() >= 3);
+    tr.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -156,6 +161,7 @@ async fn graceful_tool_error_continues_loop() {
     assert_eq!(result.answer, "Handled the error.");
     // 2 steps: tool attempt (error) + final answer
     assert_eq!(result.steps_taken, 2);
+    tr.close().await.unwrap();
 }
 
 #[tokio::test]
@@ -174,6 +180,7 @@ async fn empty_llm_response_returns_error() {
         .unwrap_err();
 
     assert!(err.to_string().contains("empty LLM response"));
+    tr.close().await.unwrap();
 }
 
 #[test]

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -1,5 +1,5 @@
 use std::io::Write;
-use tempfile::NamedTempFile;
+use tempfile::{NamedTempFile, TempDir};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::{LlmResponse, StubClient};
@@ -15,8 +15,10 @@ fn cfg(max_steps: u32) -> AgentConfig {
     }
 }
 
-fn tracer() -> Tracer {
-    Tracer::new(Uuid::new_v4(), "/tmp/yaai-agent-test-traces").expect("tracer init failed")
+fn tracer() -> (TempDir, Tracer) {
+    let tmp = tempfile::tempdir().unwrap();
+    let tr = Tracer::new(Uuid::new_v4(), tmp.path()).expect("tracer init failed");
+    (tmp, tr)
 }
 
 fn temp_file_path() -> (NamedTempFile, String) {
@@ -31,7 +33,7 @@ async fn produces_final_answer_without_tools() {
     let llm = StubClient::new(vec![LlmResponse::text("The answer is 42.")]);
     let tools = ToolRegistry::new();
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
         .run("What is the answer?")
@@ -52,7 +54,7 @@ async fn calls_tool_then_answers() {
     let mut tools = ToolRegistry::new();
     tools.register(ReadTool::new());
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
         .run("Read the file")
@@ -74,7 +76,7 @@ async fn respects_max_steps() {
     let mut tools = ToolRegistry::new();
     tools.register(ReadTool::new());
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     let err = AgentRunner::new(&cfg(3), &llm, &tools, &tr, &mut mem)
         .run("loop forever")
@@ -94,7 +96,7 @@ async fn trace_has_correct_event_sequence() {
     let mut tools = ToolRegistry::new();
     tools.register(ReadTool::new());
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     // Tracer is write-only (streams to ndjson); verify the run completed with
     // the expected step count as a proxy for correct event sequencing.
@@ -118,7 +120,7 @@ async fn memory_accumulates_across_steps() {
     let mut tools = ToolRegistry::new();
     tools.register(ReadTool::new());
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
         .run("task")
@@ -141,7 +143,7 @@ async fn graceful_tool_error_continues_loop() {
     let mut tools = ToolRegistry::new();
     tools.register(ReadTool::new());
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     // The tool error should be fed back as a ToolResult observation and the
     // loop should continue to the next LLM call rather than propagating the
@@ -164,7 +166,7 @@ async fn empty_llm_response_returns_error() {
     }]);
     let tools = ToolRegistry::new();
     let mut mem = SessionMemory::new();
-    let tr = tracer();
+    let (_tmp, tr) = tracer();
 
     let err = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
         .run("task")

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -1,0 +1,201 @@
+use std::io::Write;
+use tempfile::NamedTempFile;
+use uuid::Uuid;
+use yaai_agent_loop::{AgentConfig, AgentRunner};
+use yaai_llm::{LlmResponse, StubClient};
+use yaai_memory::SessionMemory;
+use yaai_tools::{builtin::ReadTool, ToolRegistry};
+use yaai_tracer::Tracer;
+
+fn cfg(max_steps: u32) -> AgentConfig {
+    AgentConfig {
+        id: "test-agent".to_string(),
+        system_prompt: "You are a test agent.".to_string(),
+        max_steps,
+    }
+}
+
+fn tracer() -> Tracer {
+    Tracer::new(Uuid::new_v4(), "/tmp/yaai-agent-test-traces").expect("tracer init failed")
+}
+
+fn temp_file_path() -> (NamedTempFile, String) {
+    let mut f = NamedTempFile::new().unwrap();
+    writeln!(f, "hello world").unwrap();
+    let path = f.path().to_str().unwrap().to_string();
+    (f, path)
+}
+
+#[tokio::test]
+async fn produces_final_answer_without_tools() {
+    let llm = StubClient::new(vec![LlmResponse::text("The answer is 42.")]);
+    let tools = ToolRegistry::new();
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+        .run("What is the answer?")
+        .await
+        .unwrap();
+
+    assert_eq!(result.answer, "The answer is 42.");
+    assert_eq!(result.steps_taken, 1);
+}
+
+#[tokio::test]
+async fn calls_tool_then_answers() {
+    let (_f, path) = temp_file_path();
+    let llm = StubClient::new(vec![
+        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::text("The answer is 42."),
+    ]);
+    let mut tools = ToolRegistry::new();
+    tools.register(ReadTool::new());
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+        .run("Read the file")
+        .await
+        .unwrap();
+
+    assert_eq!(result.answer, "The answer is 42.");
+    assert_eq!(result.steps_taken, 2);
+}
+
+#[tokio::test]
+async fn respects_max_steps() {
+    let (_f, path) = temp_file_path();
+    let llm = StubClient::new(vec![
+        LlmResponse::tool("read", serde_json::json!({"file_path": path.clone()})),
+        LlmResponse::tool("read", serde_json::json!({"file_path": path.clone()})),
+        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+    ]);
+    let mut tools = ToolRegistry::new();
+    tools.register(ReadTool::new());
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    let err = AgentRunner::new(&cfg(3), &llm, &tools, &tr, &mut mem)
+        .run("loop forever")
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("max_steps"));
+}
+
+#[tokio::test]
+async fn trace_has_correct_event_sequence() {
+    let (_f, path) = temp_file_path();
+    let llm = StubClient::new(vec![
+        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::text("Result is done."),
+    ]);
+    let mut tools = ToolRegistry::new();
+    tools.register(ReadTool::new());
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    // Tracer is write-only (streams to ndjson); verify the run completed with
+    // the expected step count as a proxy for correct event sequencing.
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+        .run("Read file")
+        .await
+        .unwrap();
+
+    // 2 steps: one tool call + one final answer
+    assert_eq!(result.steps_taken, 2);
+    assert_eq!(result.answer, "Result is done.");
+}
+
+#[tokio::test]
+async fn memory_accumulates_across_steps() {
+    let (_f, path) = temp_file_path();
+    let llm = StubClient::new(vec![
+        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::text("Done."),
+    ]);
+    let mut tools = ToolRegistry::new();
+    tools.register(ReadTool::new());
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+        .run("task")
+        .await
+        .unwrap();
+
+    // user task + tool result observation + final assistant = at least 3
+    assert!(mem.len() >= 3);
+}
+
+#[tokio::test]
+async fn graceful_tool_error_continues_loop() {
+    let llm = StubClient::new(vec![
+        LlmResponse::tool(
+            "read",
+            serde_json::json!({"file_path": "/nonexistent/file.txt"}),
+        ),
+        LlmResponse::text("Handled the error."),
+    ]);
+    let mut tools = ToolRegistry::new();
+    tools.register(ReadTool::new());
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    // The tool error should be fed back as a ToolResult observation and the
+    // loop should continue to the next LLM call rather than propagating the
+    // error up to the caller.
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+        .run("read missing file")
+        .await
+        .unwrap();
+
+    assert_eq!(result.answer, "Handled the error.");
+    // 2 steps: tool attempt (error) + final answer
+    assert_eq!(result.steps_taken, 2);
+}
+
+#[tokio::test]
+async fn empty_llm_response_returns_error() {
+    let llm = StubClient::new(vec![LlmResponse {
+        content: None,
+        tool_call: None,
+    }]);
+    let tools = ToolRegistry::new();
+    let mut mem = SessionMemory::new();
+    let tr = tracer();
+
+    let err = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+        .run("task")
+        .await
+        .unwrap_err();
+
+    assert!(err.to_string().contains("empty LLM response"));
+}
+
+#[test]
+fn agent_config_serde_round_trip() {
+    use yaai_agent_loop::AgentResult;
+
+    let config = AgentConfig {
+        id: "agent-1".to_string(),
+        system_prompt: "you are helpful".to_string(),
+        max_steps: 10,
+    };
+    let json = serde_json::to_string(&config).unwrap();
+    let c2: AgentConfig = serde_json::from_str(&json).unwrap();
+    assert_eq!(c2.id, "agent-1");
+    assert_eq!(c2.max_steps, 10);
+
+    let result = AgentResult {
+        run_id: uuid::Uuid::new_v4(),
+        agent_id: "agent-1".to_string(),
+        answer: "42".to_string(),
+        steps_taken: 3,
+    };
+    let json = serde_json::to_string(&result).unwrap();
+    let r2: AgentResult = serde_json::from_str(&json).unwrap();
+    assert_eq!(r2.answer, "42");
+    assert_eq!(r2.steps_taken, 3);
+}

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -16,6 +16,17 @@ pub enum Role {
     Tool,
 }
 
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Role::System => "system",
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::Tool => "tool",
+        })
+    }
+}
+
 /// A single entry in session memory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryEntry {

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,0 +1,68 @@
+//! Agent orchestration — single-agent and multi-agent sequential workflows.
+
+use anyhow::Result;
+use tracing::info;
+use uuid::Uuid;
+use yaai_agent_loop::{AgentConfig, AgentResult, AgentRunner};
+use yaai_llm::LlmClient;
+use yaai_memory::SessionMemory;
+use yaai_tools::ToolRegistry;
+use yaai_tracer::Tracer;
+
+/// Run a single agent on a task, flush the trace, and return the result.
+pub async fn run_single(
+    config: &AgentConfig,
+    task: impl Into<String>,
+    llm: &dyn LlmClient,
+    tools: &ToolRegistry,
+    run_id: Uuid,
+    traces_dir: &str,
+) -> Result<AgentResult> {
+    let tracer = Tracer::new(run_id, traces_dir)?;
+    let mut memory = SessionMemory::new();
+
+    let result = AgentRunner::new(config, llm, tools, &tracer, &mut memory)
+        .run(task)
+        .await?;
+
+    tracer.close().await?;
+    Ok(result)
+}
+
+/// One step in a sequential multi-agent workflow.
+#[derive(Debug, Clone)]
+pub struct WorkflowStep {
+    pub config: AgentConfig,
+}
+
+/// Run a sequential multi-agent workflow.
+///
+/// Each agent's answer becomes the next agent's task input.
+/// All agents share one `run_id` so their events appear in a single trace file.
+pub async fn run_sequential(
+    steps: &[WorkflowStep],
+    initial_task: impl Into<String>,
+    llm: &dyn LlmClient,
+    tools: &ToolRegistry,
+    traces_dir: &str,
+) -> Result<Vec<AgentResult>> {
+    let run_id = Uuid::new_v4();
+    let tracer = Tracer::new(run_id, traces_dir)?;
+
+    let mut current_task = initial_task.into();
+    let mut results = Vec::new();
+
+    for step in steps {
+        let mut memory = SessionMemory::new();
+        let result = AgentRunner::new(&step.config, llm, tools, &tracer, &mut memory)
+            .run(&current_task)
+            .await?;
+
+        info!(agent = %result.agent_id, steps = result.steps_taken, "agent completed");
+        current_task = result.answer.clone();
+        results.push(result);
+    }
+
+    tracer.close().await?;
+    Ok(results)
+}


### PR DESCRIPTION
## Summary

- Adds `yaai-agent-loop` crate implementing the ReAct (observe → think → act) execution loop
- `AgentRunner` drives an agent through LLM calls and tool dispatches until a final answer is produced or `max_steps` is reached
- Adds `Display` impl for `Role` in `yaai-memory` to support message role serialisation

## Changes

### New crate: `crates/agent-loop`

- `AgentConfig` — configures agent id, system prompt, and max steps
- `AgentResult` — captures run id, agent id, final answer, and steps taken
- `AgentRunner` — composes `LlmClient`, `ToolRegistry`, `SessionMemory`, and `Tracer` into the ReAct loop
- Tool errors are surfaced as observations and fed back into the loop rather than propagating to the caller
- Emits structured trace events: `Prompt`, `Decision`, `ToolCall`, `ToolResult`, `Error`, `FinalAnswer`

### Modified: `crates/memory/src/lib.rs`

- Adds `Display` for `Role` (`system`, `user`, `assistant`, `tool`)

## Tests

Seven integration tests covering:
- Final answer without tools
- Tool call followed by answer
- `max_steps` enforcement
- Correct trace event sequence (via step count)
- Memory accumulation across steps
- Graceful tool error handling
- Empty LLM response returns error
- `AgentConfig` / `AgentResult` serde round-trip