### PR TITLE
feat: add yaai-orchestrator crate with single-agent runner

### DIFF
--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "yaai-orchestrator"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+yaai-agent-loop = { path = "../agent-loop" }
+yaai-llm = { path = "../llm" }
+yaai-memory = { path = "../memory" }
+yaai-tools = { path = "../tools" }
+yaai-tracer = { path = "../tracer" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+uuid = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,0 +1,7 @@
+//! Agent orchestration — single-agent and multi-agent sequential workflows.
+
+mod sequential;
+mod single;
+
+pub use sequential::{run_sequential, WorkflowStep};
+pub use single::run_single;

--- a/crates/orchestrator/src/single.rs
+++ b/crates/orchestrator/src/single.rs
@@ -1,0 +1,26 @@
+use anyhow::Result;
+use uuid::Uuid;
+use yaai_agent_loop::{AgentConfig, AgentResult, AgentRunner};
+use yaai_llm::LlmClient;
+use yaai_memory::SessionMemory;
+use yaai_tools::ToolRegistry;
+use yaai_tracer::Tracer;
+
+/// Run a single agent on a task, flush the trace, and return the result.
+pub async fn run_single(
+    config: &AgentConfig,
+    task: impl Into<String>,
+    llm: &dyn LlmClient,
+    tools: &ToolRegistry,
+    traces_dir: &str,
+) -> Result<AgentResult> {
+    let tracer = Tracer::new(Uuid::new_v4(), traces_dir)?;
+    let mut memory = SessionMemory::new();
+
+    let result = AgentRunner::new(config, llm, tools, &tracer, &mut memory)
+        .run(task)
+        .await?;
+
+    tracer.close().await?;
+    Ok(result)
+}

--- a/crates/orchestrator/tests/single.rs
+++ b/crates/orchestrator/tests/single.rs
@@ -1,0 +1,26 @@
+use yaai_agent_loop::AgentConfig;
+use yaai_llm::{LlmResponse, StubClient};
+use yaai_orchestrator::run_single;
+use yaai_tools::ToolRegistry;
+
+fn cfg(id: &str) -> AgentConfig {
+    AgentConfig {
+        id: id.to_string(),
+        system_prompt: format!("You are the {id} agent."),
+        max_steps: 10,
+    }
+}
+
+#[tokio::test]
+async fn single_agent_completes() {
+    let llm = StubClient::new(vec![LlmResponse::text("final answer")]);
+    let tools = ToolRegistry::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let result = run_single(&cfg("solo"), "do a task", &llm, &tools, dir.path().to_str().unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(result.answer, "final answer");
+    assert_eq!(result.agent_id, "solo");
+}


### PR DESCRIPTION
## Summary

- Adds the `yaai-orchestrator` crate responsible for workflow coordination, composing `agent-loop` instances
- Implements `run_single` — a single-agent runner that wires together `AgentRunner`, `SessionMemory`, and `Tracer`
- Includes an integration test using `StubClient` to verify a single agent completes a task without real LLM calls