### PR TITLE
refactor: rename ClaudeClient to AnthropicClient

### DIFF
--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -14,13 +14,13 @@ const DEFAULT_MODEL: &str = "claude-sonnet-4-5";
 const DEFAULT_MAX_TOKENS: u32 = 4096;
 
 #[derive(Debug, Clone)]
-pub struct ClaudeClient {
+pub struct AnthropicClient {
     api_key: String,
     model: String,
     client: reqwest::Client,
 }
 
-impl ClaudeClient {
+impl AnthropicClient {
     pub fn new(api_key: impl Into<String>, model: impl Into<String>) -> Self {
         Self::with_client(api_key, model, crate::default_http_client())
     }
@@ -80,7 +80,7 @@ enum ContentBlock {
 
 // grcov-excl-start
 #[async_trait]
-impl LlmClient for ClaudeClient {
+impl LlmClient for AnthropicClient {
     async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
         debug!(model = %self.model, messages = messages.len(), "calling Claude");
 

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -82,7 +82,7 @@ enum ContentBlock {
 #[async_trait]
 impl LlmClient for AnthropicClient {
     async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
-        debug!(model = %self.model, messages = messages.len(), "calling Claude");
+        debug!(model = %self.model, messages = messages.len(), "calling Anthropic");
 
         let body = MessagesRequest {
             model: &self.model,

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -3,9 +3,9 @@
 //! Defines the [`LlmClient`] trait and provides:
 //! - [`StubClient`]: scripted responses for deterministic testing
 //! - [`OpenAiClient`]: calls the OpenAI chat completions API
-//! - [`ClaudeClient`]: calls the Anthropic Messages API
+//! - [`AnthropicClient`]: calls the Anthropic Messages API
 
-pub mod claude;
+pub mod anthropic;
 pub mod openai;
 pub mod stub;
 
@@ -23,7 +23,7 @@ pub(crate) fn default_http_client() -> reqwest::Client {
         .expect("failed to build reqwest client")
 }
 
-pub use claude::ClaudeClient;
+pub use anthropic::AnthropicClient;
 pub use openai::OpenAiClient;
 pub use stub::StubClient;
 

--- a/crates/llm/tests/stub_tests.rs
+++ b/crates/llm/tests/stub_tests.rs
@@ -152,15 +152,15 @@ fn tool_call_serde_round_trip() {
 
 #[test]
 fn claude_client_new_empty_model_uses_default() {
-    use yaai_llm::ClaudeClient;
+    use yaai_llm::AnthropicClient;
     // Empty model string should fall back to the built-in default — just verify construction succeeds
-    let _ = ClaudeClient::new("test-api-key", "");
+    let _ = AnthropicClient::new("test-api-key", "");
 }
 
 #[test]
 fn claude_client_new_explicit_model() {
-    use yaai_llm::ClaudeClient;
-    let _ = ClaudeClient::new("test-api-key", "claude-3-opus");
+    use yaai_llm::AnthropicClient;
+    let _ = AnthropicClient::new("test-api-key", "claude-3-opus");
 }
 
 #[test]

--- a/crates/llm/tests/stub_tests.rs
+++ b/crates/llm/tests/stub_tests.rs
@@ -151,14 +151,14 @@ fn tool_call_serde_round_trip() {
 }
 
 #[test]
-fn claude_client_new_empty_model_uses_default() {
+fn anthropic_client_new_empty_model_uses_default() {
     use yaai_llm::AnthropicClient;
     // Empty model string should fall back to the built-in default — just verify construction succeeds
     let _ = AnthropicClient::new("test-api-key", "");
 }
 
 #[test]
-fn claude_client_new_explicit_model() {
+fn anthropic_client_new_explicit_model() {
     use yaai_llm::AnthropicClient;
     let _ = AnthropicClient::new("test-api-key", "claude-3-opus");
 }


### PR DESCRIPTION
## Summary

- Renames `crates/llm/src/claude.rs` → `crates/llm/src/anthropic.rs`
- Renames `ClaudeClient` struct and `impl` blocks to `AnthropicClient`
- Updates `pub use` re-export in `lib.rs` and the module doc comment
- Updates test references in `crates/llm/tests/stub_tests.rs`

The previous name `ClaudeClient` referred to a specific model family rather than the provider. `AnthropicClient` better reflects that this client targets the Anthropic Messages API, consistent with how `OpenAiClient` names the OpenAI client.