### PR TITLE
fix(cli): improve help formatting and wrapping

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -179,6 +179,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -1249,6 +1250,16 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminal_size"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+dependencies = [
+ "rustix",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
 # CLI
-clap = { version = "4.5", features = ["derive", "env"] }
+clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 
 [profile.dev]
 opt-level = 0

--- a/apps/cli/src/commands/llm.rs
+++ b/apps/cli/src/commands/llm.rs
@@ -11,8 +11,11 @@ pub fn parse_provider_model(s: &str) -> Result<(Provider, String)> {
     let (provider_str, model) = s
         .split_once('/')
         .ok_or_else(|| anyhow!("--model must be in format provider/model (e.g. openai/gpt-4o)"))?;
-    if model.trim().is_empty() {
-        bail!("--model must include a model name after the provider (e.g. openai/gpt-4o)");
+    let provider_str = provider_str.trim();
+    let model = model.trim();
+
+    if provider_str.is_empty() || model.is_empty() {
+        bail!("--model must include non-empty provider and model segments");
     }
     let provider = match provider_str {
         "openai" => Provider::OpenAi,
@@ -29,19 +32,25 @@ pub fn validate_api_key(key: &str, var_name: &str) -> Result<()> {
     Ok(())
 }
 
+fn normalize_api_key(key: String, var_name: &str) -> Result<String> {
+    let key = key.trim().to_string();
+    validate_api_key(&key, var_name)?;
+    Ok(key)
+}
+
 pub fn build_llm_client(provider: &Provider, model: &str) -> Result<Box<dyn LlmClient>> {
     // grcov-excl-start
     match provider {
         Provider::OpenAi => {
             let api_key =
                 std::env::var("OPENAI_API_KEY").context("OPENAI_API_KEY env var not set")?;
-            validate_api_key(&api_key, "OPENAI_API_KEY")?;
+            let api_key = normalize_api_key(api_key, "OPENAI_API_KEY")?;
             Ok(Box::new(OpenAiClient::new(api_key, model)))
         }
         Provider::Anthropic => {
             let api_key =
                 std::env::var("ANTHROPIC_API_KEY").context("ANTHROPIC_API_KEY env var not set")?;
-            validate_api_key(&api_key, "ANTHROPIC_API_KEY")?;
+            let api_key = normalize_api_key(api_key, "ANTHROPIC_API_KEY")?;
             Ok(Box::new(AnthropicClient::new(api_key, model)))
         }
     }
@@ -55,6 +64,13 @@ mod tests {
     #[test]
     fn parse_openai_model() {
         let (provider, model) = parse_provider_model("openai/gpt-4o").unwrap();
+        assert_eq!(provider, Provider::OpenAi);
+        assert_eq!(model, "gpt-4o");
+    }
+
+    #[test]
+    fn parse_provider_model_trims_segments() {
+        let (provider, model) = parse_provider_model("  openai  /  gpt-4o  ").unwrap();
         assert_eq!(provider, Provider::OpenAi);
         assert_eq!(model, "gpt-4o");
     }
@@ -82,13 +98,13 @@ mod tests {
     #[test]
     fn parse_empty_model_fails() {
         let err = parse_provider_model("openai/").unwrap_err();
-        assert!(err.to_string().contains("model name"));
+        assert!(err.to_string().contains("non-empty provider and model"));
     }
 
     #[test]
     fn parse_whitespace_model_fails() {
         let err = parse_provider_model("openai/   ").unwrap_err();
-        assert!(err.to_string().contains("model name"));
+        assert!(err.to_string().contains("non-empty provider and model"));
     }
 
     #[test]
@@ -106,5 +122,17 @@ mod tests {
     #[test]
     fn validate_api_key_accepts_valid() {
         assert!(validate_api_key("sk-abc123", "MY_KEY").is_ok());
+    }
+
+    #[test]
+    fn normalize_api_key_trims_value() {
+        let key = normalize_api_key("  sk-abc123\n".to_string(), "MY_KEY").unwrap();
+        assert_eq!(key, "sk-abc123");
+    }
+
+    #[test]
+    fn normalize_api_key_rejects_whitespace_only() {
+        let err = normalize_api_key("   \n\t".to_string(), "MY_KEY").unwrap_err();
+        assert!(err.to_string().contains("MY_KEY must not be empty"));
     }
 }

--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -16,6 +16,8 @@ pub struct PromptArgs {
         short = 'p',
         long,
         value_name = "PROMPT",
+        display_order = 1,
+        help_heading = "Arguments",
         value_parser = |s: &str| -> Result<String, String> {
             if s.trim().is_empty() {
                 Err("prompt must not be empty".to_string())
@@ -32,7 +34,8 @@ pub struct PromptArgs {
         short = 'm',
         long,
         value_name = "PROVIDER/MODEL",
-        default_value = "openai/gpt-4o",
+        display_order = 2,
+        help_heading = "Arguments",
         help = "The model to use, specified as provider/model (e.g. openai/gpt-4o, \
                 anthropic/claude-3-5-sonnet-20241022). The corresponding API key must be \
                 set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY)."
@@ -42,6 +45,8 @@ pub struct PromptArgs {
     #[arg(
         long,
         default_value = "traces",
+        display_order = 13,
+        help_heading = "Options",
         help = "Directory where trace files are written after each run. \
                 Each run produces a file named <run-id>.ndjson containing \
                 newline-delimited JSON (NDJSON) — one event object per line."

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -3,16 +3,52 @@
 mod commands;
 
 use anyhow::Result;
-use clap::Parser;
+use clap::{ArgAction, Parser};
 use commands::prompt::PromptArgs;
 use yaai_tracer::init_tracing;
 
 #[derive(Parser)]
-#[command(name = "yaai", about = "POC Agent Harness", version)]
+#[command(
+    name = "yaai",
+    about = "POC Agent Harness",
+    version,
+    max_term_width = 100,
+    disable_help_flag = true,
+    disable_version_flag = true,
+    help_template = "\
+{before-help}{about-with-newline}\
+{usage-heading} {usage}\n\n\
+{all-args}{after-help}\
+"
+)]
 struct Cli {
+    #[arg(
+        short = 'h',
+        long = "help",
+        action = ArgAction::Help,
+        global = true,
+        display_order = 10,
+        help_heading = "Options",
+        help = "Print help"
+    )]
+    _help: Option<bool>,
+
+    #[arg(
+        short = 'V',
+        long = "version",
+        action = ArgAction::Version,
+        global = true,
+        display_order = 11,
+        help_heading = "Options",
+        help = "Print version"
+    )]
+    _version: Option<bool>,
+
     #[arg(
         long,
         global = true,
+        display_order = 12,
+        help_heading = "Options",
         help = "Emit logs as structured JSON instead of pretty-printed text. \
                 Useful when piping output to a log aggregator or structured logging pipeline."
     )]

--- a/crates/orchestrator/src/single.rs
+++ b/crates/orchestrator/src/single.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentResult, AgentRunner};
 use yaai_llm::LlmClient;
@@ -19,8 +19,16 @@ pub async fn run_single(
 
     let result = AgentRunner::new(config, llm, tools, &tracer, &mut memory)
         .run(task)
-        .await?;
+        .await;
 
-    tracer.close().await?;
-    Ok(result)
+    let close_result = tracer.close().await;
+
+    match (result, close_result) {
+        (Ok(result), Ok(())) => Ok(result),
+        (Err(run_err), Ok(())) => Err(run_err),
+        (Ok(_), Err(close_err)) => Err(close_err),
+        (Err(run_err), Err(close_err)) => {
+            Err(run_err).context(format!("failed to close tracer cleanly: {close_err}"))
+        }
+    }
 }

--- a/crates/orchestrator/tests/single.rs
+++ b/crates/orchestrator/tests/single.rs
@@ -30,3 +30,27 @@ async fn single_agent_completes() {
     assert_eq!(result.answer, "final answer");
     assert_eq!(result.agent_id, "solo");
 }
+
+#[tokio::test]
+async fn single_agent_closes_tracer_on_error() {
+    let llm = StubClient::new(vec![]);
+    let tools = ToolRegistry::new();
+    let dir = tempfile::tempdir().unwrap();
+
+    let err = run_single(&cfg("solo"), "do a task", &llm, &tools, dir.path().to_str().unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(
+        err.to_string().contains("StubClient script exhausted"),
+        "unexpected error: {err}"
+    );
+
+    let trace_files = std::fs::read_dir(dir.path())
+        .unwrap()
+        .map(|entry| entry.unwrap().path())
+        .collect::<Vec<_>>();
+
+    assert_eq!(trace_files.len(), 1);
+    assert_eq!(trace_files[0].extension().and_then(|ext| ext.to_str()), Some("ndjson"));
+}


### PR DESCRIPTION
## Summary

This one was making it hard for me to read command information

- widen the clap help layout so long descriptions stay in a readable column
- group required flags under an `Arguments` heading and keep all optional flags in a single `Options` section
- replace clap's implicit help/version flags with explicit ones so the help output avoids duplicated section headers


## Before
<img width="970" height="266" alt="image" src="https://github.com/user-attachments/assets/0cd5357e-dee1-40de-99c4-31b75531d279" />

## After
<img width="715" height="310" alt="image" src="https://github.com/user-attachments/assets/7264fd85-574e-4485-b115-90d6553edeec" />



## Verification
- `cargo run -q -p yaai -- -h`
- `cargo run -q -p yaai -- -V`