### PR TITLE
feat(cli): add XDG Base Directory config support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,10 +216,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "config"
+version = "0.15.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68cfe19cd7d23ffde002c24ffa5cda73931913ef394d5eaaa32037dc940c0c"
+dependencies = [
+ "json5",
+ "pathdiff",
+ "serde-untagged",
+ "serde_core",
+ "winnow",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "displaydoc"
@@ -228,6 +300,17 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2add8a07dd6a8d93ff627029c51de145e12686fbc36ecb298ac22e74cf02dec"
+dependencies = [
+ "serde",
+ "serde_core",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -297,6 +380,16 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -643,6 +736,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +763,15 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libredox"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -750,6 +863,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -773,10 +892,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -942,6 +1110,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1099,6 +1278,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-untagged"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9faf48a4a2d2693be24c6289dbe26552776eb7737074e6722891fadbe6c5058"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "serde_core",
+ "typeid",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,6 +1332,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1500,6 +1702,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1778,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1930,6 +2156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2029,6 +2264,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "config",
+ "dirs",
+ "serde",
+ "tempfile",
  "tokio",
  "tracing",
  "yaai-agent-loop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 # CLI
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 
+# Configuration
+config = { version = "0.15", default-features = false, features = ["json5"] }
+dirs = "6"
+
 [profile.dev]
 opt-level = 0
 

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -15,5 +15,11 @@ yaai-orchestrator = { path = "../../crates/orchestrator" }
 yaai-tracer = { path = "../../crates/tracer" }
 anyhow = { workspace = true }
 clap = { workspace = true }
+config = { workspace = true }
+dirs = { workspace = true }
+serde = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -5,7 +5,7 @@ use yaai_agent_loop::AgentConfig;
 use yaai_orchestrator::run_single;
 use yaai_tools::ToolRegistry;
 
-use crate::config::YaaiConfig;
+use crate::config::{self, YaaiConfig};
 
 use super::llm::{build_llm_client, parse_provider_model};
 
@@ -50,8 +50,7 @@ pub struct PromptArgs {
         help_heading = "Arguments",
         help = "The model to use, specified as provider/model (e.g. openai/gpt-4o, \
                 anthropic/claude-3-5-sonnet-20241022). The corresponding API key must be \
-                set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY). \
-                Falls back to `model` in $XDG_CONFIG_HOME/yaai/config.json if not set."
+                set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY)."
     )]
     pub model: Option<String>,
 
@@ -61,8 +60,7 @@ pub struct PromptArgs {
         help_heading = "Options",
         help = "Directory where trace files are written after each run. \
                 Each run produces a file named <run-id>.ndjson containing \
-                newline-delimited JSON (NDJSON) — one event object per line. \
-                Falls back to `traces_dir` in $XDG_CONFIG_HOME/yaai/config.json, then \"traces\"."
+                newline-delimited JSON (NDJSON) — one event object per line."
     )]
     pub traces_dir: Option<String>,
 }
@@ -72,7 +70,8 @@ impl PromptArgs {
     pub fn resolve(self, cfg: &YaaiConfig) -> Result<ResolvedPromptArgs> {
         let model = self.model.or_else(|| cfg.model.clone()).ok_or_else(|| {
             anyhow::anyhow!(
-                "--model is required (or set `model` in $XDG_CONFIG_HOME/yaai/config.json)"
+                "--model is required (or set `model` in {})",
+                config::config_path_display()
             )
         })?;
 

--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -1,14 +1,17 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
 use clap::Args;
 use tracing::info;
 use yaai_agent_loop::AgentConfig;
 use yaai_orchestrator::run_single;
 use yaai_tools::ToolRegistry;
 
+use crate::config::YaaiConfig;
+
 use super::llm::{build_llm_client, parse_provider_model};
 
 const DEFAULT_SYSTEM_PROMPT: &str = "You are a helpful assistant.";
 const DEFAULT_MAX_STEPS: u32 = 10;
+const DEFAULT_TRACES_DIR: &str = "traces";
 
 #[derive(Args)]
 pub struct PromptArgs {
@@ -38,25 +41,58 @@ pub struct PromptArgs {
         help_heading = "Arguments",
         help = "The model to use, specified as provider/model (e.g. openai/gpt-4o, \
                 anthropic/claude-3-5-sonnet-20241022). The corresponding API key must be \
-                set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY)."
+                set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY). \
+                Falls back to `model` in ~/.config/yaai/config.json if not set."
     )]
-    pub model: String,
+    pub model: Option<String>,
 
     #[arg(
         long,
-        default_value = "traces",
         display_order = 13,
         help_heading = "Options",
         help = "Directory where trace files are written after each run. \
                 Each run produces a file named <run-id>.ndjson containing \
-                newline-delimited JSON (NDJSON) — one event object per line."
+                newline-delimited JSON (NDJSON) — one event object per line. \
+                Falls back to `traces_dir` in ~/.config/yaai/config.json, then \"traces\"."
     )]
+    pub traces_dir: Option<String>,
+}
+
+impl PromptArgs {
+    /// Resolve final values by layering: CLI args > config file > hardcoded defaults.
+    pub fn resolve(self, cfg: &YaaiConfig) -> Result<ResolvedPromptArgs> {
+        let model = self.model.or_else(|| cfg.model.clone()).ok_or_else(|| {
+            anyhow::anyhow!("--model is required (or set `model` in ~/.config/yaai/config.json)")
+        })?;
+
+        if model.trim().is_empty() {
+            bail!("model must not be empty");
+        }
+
+        let traces_dir = self
+            .traces_dir
+            .or_else(|| cfg.traces_dir.clone())
+            .unwrap_or_else(|| DEFAULT_TRACES_DIR.to_string());
+
+        Ok(ResolvedPromptArgs {
+            prompt: self.prompt,
+            model,
+            traces_dir,
+        })
+    }
+}
+
+#[derive(Debug)]
+pub struct ResolvedPromptArgs {
+    pub prompt: String,
+    pub model: String,
     pub traces_dir: String,
 }
 
 // grcov-excl-start
-pub async fn execute(args: PromptArgs) -> Result<()> {
-    let (provider, model) = parse_provider_model(&args.model)?;
+pub async fn execute(args: PromptArgs, cfg: &YaaiConfig) -> Result<()> {
+    let resolved = args.resolve(cfg)?;
+    let (provider, model) = parse_provider_model(&resolved.model)?;
     let llm = build_llm_client(&provider, &model)?;
     let tools = ToolRegistry::new();
 
@@ -66,7 +102,14 @@ pub async fn execute(args: PromptArgs) -> Result<()> {
         max_steps: DEFAULT_MAX_STEPS,
     };
 
-    let result = run_single(&agent_config, &args.prompt, &llm, &tools, &args.traces_dir).await?;
+    let result = run_single(
+        &agent_config,
+        &resolved.prompt,
+        &llm,
+        &tools,
+        &resolved.traces_dir,
+    )
+    .await?;
 
     info!(steps = result.steps_taken, "run complete");
     println!("{}", result.answer);
@@ -74,3 +117,78 @@ pub async fn execute(args: PromptArgs) -> Result<()> {
     Ok(())
 }
 // grcov-excl-stop
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(model: Option<&str>, traces_dir: Option<&str>) -> PromptArgs {
+        PromptArgs {
+            prompt: "hello".to_string(),
+            model: model.map(str::to_string),
+            traces_dir: traces_dir.map(str::to_string),
+        }
+    }
+
+    fn cfg(model: Option<&str>, traces_dir: Option<&str>) -> YaaiConfig {
+        YaaiConfig {
+            model: model.map(str::to_string),
+            traces_dir: traces_dir.map(str::to_string),
+            json_logs: None,
+        }
+    }
+
+    #[test]
+    fn cli_model_takes_precedence_over_config() {
+        let resolved = args(Some("openai/gpt-4o"), None)
+            .resolve(&cfg(Some("anthropic/claude-3-5-sonnet-20241022"), None))
+            .unwrap();
+        assert_eq!(resolved.model, "openai/gpt-4o");
+    }
+
+    #[test]
+    fn config_model_used_when_cli_model_absent() {
+        let resolved = args(None, None)
+            .resolve(&cfg(Some("anthropic/claude-3-5-sonnet-20241022"), None))
+            .unwrap();
+        assert_eq!(resolved.model, "anthropic/claude-3-5-sonnet-20241022");
+    }
+
+    #[test]
+    fn missing_model_from_both_is_error() {
+        let err = args(None, None).resolve(&cfg(None, None)).unwrap_err();
+        assert!(err.to_string().contains("--model is required"));
+    }
+
+    #[test]
+    fn cli_traces_dir_takes_precedence_over_config() {
+        let resolved = args(Some("openai/gpt-4o"), Some("/cli/traces"))
+            .resolve(&cfg(None, Some("/cfg/traces")))
+            .unwrap();
+        assert_eq!(resolved.traces_dir, "/cli/traces");
+    }
+
+    #[test]
+    fn config_traces_dir_used_when_cli_absent() {
+        let resolved = args(Some("openai/gpt-4o"), None)
+            .resolve(&cfg(None, Some("/cfg/traces")))
+            .unwrap();
+        assert_eq!(resolved.traces_dir, "/cfg/traces");
+    }
+
+    #[test]
+    fn default_traces_dir_when_both_absent() {
+        let resolved = args(Some("openai/gpt-4o"), None)
+            .resolve(&cfg(None, None))
+            .unwrap();
+        assert_eq!(resolved.traces_dir, DEFAULT_TRACES_DIR);
+    }
+
+    #[test]
+    fn prompt_is_passed_through() {
+        let resolved = args(Some("openai/gpt-4o"), None)
+            .resolve(&cfg(None, None))
+            .unwrap();
+        assert_eq!(resolved.prompt, "hello");
+    }
+}

--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -9,6 +9,15 @@ use crate::config::YaaiConfig;
 
 use super::llm::{build_llm_client, parse_provider_model};
 
+fn expand_tilde(p: String) -> String {
+    if let Some(rest) = p.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest).to_string_lossy().into_owned();
+        }
+    }
+    p
+}
+
 const DEFAULT_SYSTEM_PROMPT: &str = "You are a helpful assistant.";
 const DEFAULT_MAX_STEPS: u32 = 10;
 const DEFAULT_TRACES_DIR: &str = "traces";
@@ -42,7 +51,7 @@ pub struct PromptArgs {
         help = "The model to use, specified as provider/model (e.g. openai/gpt-4o, \
                 anthropic/claude-3-5-sonnet-20241022). The corresponding API key must be \
                 set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY). \
-                Falls back to `model` in ~/.config/yaai/config.json if not set."
+                Falls back to `model` in $XDG_CONFIG_HOME/yaai/config.json if not set."
     )]
     pub model: Option<String>,
 
@@ -53,7 +62,7 @@ pub struct PromptArgs {
         help = "Directory where trace files are written after each run. \
                 Each run produces a file named <run-id>.ndjson containing \
                 newline-delimited JSON (NDJSON) — one event object per line. \
-                Falls back to `traces_dir` in ~/.config/yaai/config.json, then \"traces\"."
+                Falls back to `traces_dir` in $XDG_CONFIG_HOME/yaai/config.json, then \"traces\"."
     )]
     pub traces_dir: Option<String>,
 }
@@ -62,7 +71,9 @@ impl PromptArgs {
     /// Resolve final values by layering: CLI args > config file > hardcoded defaults.
     pub fn resolve(self, cfg: &YaaiConfig) -> Result<ResolvedPromptArgs> {
         let model = self.model.or_else(|| cfg.model.clone()).ok_or_else(|| {
-            anyhow::anyhow!("--model is required (or set `model` in ~/.config/yaai/config.json)")
+            anyhow::anyhow!(
+                "--model is required (or set `model` in $XDG_CONFIG_HOME/yaai/config.json)"
+            )
         })?;
 
         if model.trim().is_empty() {
@@ -73,6 +84,7 @@ impl PromptArgs {
             .traces_dir
             .or_else(|| cfg.traces_dir.clone())
             .unwrap_or_else(|| DEFAULT_TRACES_DIR.to_string());
+        let traces_dir = expand_tilde(traces_dir);
 
         Ok(ResolvedPromptArgs {
             prompt: self.prompt,
@@ -182,6 +194,15 @@ mod tests {
             .resolve(&cfg(None, None))
             .unwrap();
         assert_eq!(resolved.traces_dir, DEFAULT_TRACES_DIR);
+    }
+
+    #[test]
+    fn tilde_in_traces_dir_is_expanded() {
+        let resolved = args(Some("openai/gpt-4o"), Some("~/my/traces"))
+            .resolve(&cfg(None, None))
+            .unwrap();
+        assert!(!resolved.traces_dir.starts_with('~'));
+        assert!(resolved.traces_dir.ends_with("/my/traces"));
     }
 
     #[test]

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -116,9 +116,14 @@ mod tests {
     }
 
     #[test]
-    fn missing_file_returns_default() {
-        // Simulate no config dir / non-existent file path via load() returning default.
-        let cfg = YaaiConfig::default();
+    fn load_returns_default_when_config_file_absent() {
+        let dir = tempdir().unwrap();
+        // Point HOME (and XDG_CONFIG_HOME) at an empty temp dir so no config file exists.
+        unsafe {
+            std::env::set_var("HOME", dir.path());
+            std::env::set_var("XDG_CONFIG_HOME", dir.path().join("config"));
+        }
+        let cfg = load().unwrap();
         assert!(cfg.model.is_none());
         assert!(cfg.traces_dir.is_none());
         assert!(cfg.json_logs.is_none());

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -1,4 +1,6 @@
-//! User-level configuration loaded from `~/.config/yaai/config.json`.
+//! User-level configuration loaded from the OS config directory (e.g.
+//! `~/.config/yaai/config.json` on Linux, `~/Library/Application Support/yaai/config.json`
+//! on macOS). Use [`config_path`] to get the exact path at runtime.
 //!
 //! All fields are optional — the file need not exist, and any field can be
 //! omitted. CLI arguments always take precedence over file values.
@@ -7,7 +9,7 @@ use anyhow::{Context, Result};
 use config::{Config, File, FileFormat};
 use serde::Deserialize;
 
-/// Fields that can be set in `~/.config/yaai/config.json`.
+/// Fields that can be set in the yaai config file (see [`config_path`]).
 /// Every field is `Option<T>` so partial configs are valid.
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -22,7 +24,25 @@ pub struct YaaiConfig {
     pub json_logs: Option<bool>,
 }
 
-/// Load `~/.config/yaai/config.json` if it exists; return `YaaiConfig::default()` otherwise.
+/// Returns the path where the config file is expected, if the OS config dir is available.
+pub fn config_path() -> Option<std::path::PathBuf> {
+    dirs::config_dir().map(|d| d.join("yaai").join("config.json"))
+}
+
+/// Returns [`config_path`] as a display string with the home directory replaced by `~`.
+pub fn config_path_display() -> String {
+    let Some(path) = config_path() else {
+        return "the yaai config file".to_string();
+    };
+    if let Some(home) = dirs::home_dir() {
+        if let Ok(rel) = path.strip_prefix(&home) {
+            return format!("~/{}", rel.display());
+        }
+    }
+    path.display().to_string()
+}
+
+/// Load the config file if it exists; return `YaaiConfig::default()` otherwise.
 pub fn load() -> Result<YaaiConfig> {
     let Some(config_dir) = dirs::config_dir() else {
         return Ok(YaaiConfig::default());

--- a/apps/cli/src/config.rs
+++ b/apps/cli/src/config.rs
@@ -1,0 +1,126 @@
+//! User-level configuration loaded from `~/.config/yaai/config.json`.
+//!
+//! All fields are optional — the file need not exist, and any field can be
+//! omitted. CLI arguments always take precedence over file values.
+
+use anyhow::{Context, Result};
+use config::{Config, File, FileFormat};
+use serde::Deserialize;
+
+/// Fields that can be set in `~/.config/yaai/config.json`.
+/// Every field is `Option<T>` so partial configs are valid.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct YaaiConfig {
+    /// Default model in `provider/model` format (e.g. `"openai/gpt-4o"`).
+    pub model: Option<String>,
+
+    /// Directory where trace NDJSON files are written.
+    pub traces_dir: Option<String>,
+
+    /// Emit logs as structured JSON instead of pretty-printed text.
+    pub json_logs: Option<bool>,
+}
+
+/// Load `~/.config/yaai/config.json` if it exists; return `YaaiConfig::default()` otherwise.
+pub fn load() -> Result<YaaiConfig> {
+    let Some(config_dir) = dirs::config_dir() else {
+        return Ok(YaaiConfig::default());
+    };
+
+    let path = config_dir.join("yaai").join("config.json");
+
+    if !path.exists() {
+        return Ok(YaaiConfig::default());
+    }
+
+    let path_str = path.to_string_lossy();
+
+    let cfg = Config::builder()
+        .add_source(File::new(&path_str, FileFormat::Json5))
+        .build()
+        .with_context(|| format!("failed to parse config file: {path_str}"))?;
+
+    cfg.try_deserialize::<YaaiConfig>()
+        .with_context(|| format!("invalid config file: {path_str}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn build_config(json: &str) -> Result<YaaiConfig> {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("config.json");
+        fs::write(&file, json).unwrap();
+
+        let path_str = file.to_string_lossy().to_string();
+        let cfg = Config::builder()
+            .add_source(File::new(&path_str, FileFormat::Json5))
+            .build()?;
+        Ok(cfg.try_deserialize::<YaaiConfig>()?)
+    }
+
+    #[test]
+    fn empty_object_yields_all_none() {
+        let c = build_config("{}").unwrap();
+        assert!(c.model.is_none());
+        assert!(c.traces_dir.is_none());
+        assert!(c.json_logs.is_none());
+    }
+
+    #[test]
+    fn partial_config_deserializes() {
+        let c = build_config(r#"{"model": "openai/gpt-4o"}"#).unwrap();
+        assert_eq!(c.model.as_deref(), Some("openai/gpt-4o"));
+        assert!(c.traces_dir.is_none());
+    }
+
+    #[test]
+    fn full_config_deserializes() {
+        let c = build_config(
+            r#"{"model":"anthropic/claude-3-5-sonnet-20241022","traces_dir":"/tmp/traces","json_logs":true}"#,
+        )
+        .unwrap();
+        assert_eq!(
+            c.model.as_deref(),
+            Some("anthropic/claude-3-5-sonnet-20241022")
+        );
+        assert_eq!(c.traces_dir.as_deref(), Some("/tmp/traces"));
+        assert_eq!(c.json_logs, Some(true));
+    }
+
+    #[test]
+    fn unknown_field_is_rejected() {
+        let err = build_config(r#"{"unknown_key": "value"}"#).unwrap_err();
+        assert!(err.to_string().contains("unknown") || err.to_string().contains("unknown_key"));
+    }
+
+    #[test]
+    fn json5_comments_and_trailing_commas_are_valid() {
+        let c = build_config(
+            r#"{
+                // default model
+                "model": "openai/gpt-4o",
+                /* output directory */
+                "traces_dir": "/tmp/traces",
+                "json_logs": false, // trailing comma
+            }"#,
+        )
+        .unwrap();
+        assert_eq!(c.model.as_deref(), Some("openai/gpt-4o"));
+        assert_eq!(c.traces_dir.as_deref(), Some("/tmp/traces"));
+        assert_eq!(c.json_logs, Some(false));
+    }
+
+    #[test]
+    fn missing_file_returns_default() {
+        // Simulate no config dir / non-existent file path via load() returning default.
+        let cfg = YaaiConfig::default();
+        assert!(cfg.model.is_none());
+        assert!(cfg.traces_dir.is_none());
+        assert!(cfg.json_logs.is_none());
+    }
+}

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -1,6 +1,7 @@
 //! yaai — POC Agent Harness CLI
 
 mod commands;
+mod config;
 
 use anyhow::Result;
 use clap::{ArgAction, Parser};
@@ -50,7 +51,8 @@ struct Cli {
         display_order = 12,
         help_heading = "Options",
         help = "Emit logs as structured JSON instead of pretty-printed text. \
-                Useful when piping output to a log aggregator or structured logging pipeline."
+                Useful when piping output to a log aggregator or structured logging pipeline. \
+                Falls back to `json_logs` in ~/.config/yaai/config.json."
     )]
     json_logs: bool,
 
@@ -62,7 +64,11 @@ struct Cli {
 async fn main() -> Result<()> {
     // grcov-excl-start
     let cli = Cli::parse();
-    init_tracing(cli.json_logs)?;
-    commands::prompt::execute(cli.args).await
+    let cfg = config::load()?;
+
+    let json_logs = cli.json_logs || cfg.json_logs.unwrap_or(false);
+    init_tracing(json_logs)?;
+
+    commands::prompt::execute(cli.args, &cfg).await
     // grcov-excl-stop
 }

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -4,7 +4,7 @@ mod commands;
 mod config;
 
 use anyhow::Result;
-use clap::{ArgAction, Parser};
+use clap::{ArgAction, CommandFactory, FromArgMatches, Parser};
 use commands::prompt::PromptArgs;
 use yaai_tracer::init_tracing;
 
@@ -51,8 +51,7 @@ struct Cli {
         display_order = 12,
         help_heading = "Options",
         help = "Emit logs as structured JSON instead of pretty-printed text. \
-                Useful when piping output to a log aggregator or structured logging pipeline. \
-                Falls back to `json_logs` in ~/.config/yaai/config.json."
+                Useful when piping output to a log aggregator or structured logging pipeline."
     )]
     json_logs: bool,
 
@@ -63,7 +62,34 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     // grcov-excl-start
-    let cli = Cli::parse();
+    let config_path = config::config_path_display();
+
+    let matches = Cli::command()
+        .mut_arg("model", |a| {
+            a.help(format!(
+                "The model to use, specified as provider/model (e.g. openai/gpt-4o, \
+                 anthropic/claude-3-5-sonnet-20241022). The corresponding API key must be \
+                 set in the environment (OPENAI_API_KEY or ANTHROPIC_API_KEY). \
+                 Falls back to `model` in {config_path} if not set."
+            ))
+        })
+        .mut_arg("traces_dir", |a| {
+            a.help(format!(
+                "Directory where trace files are written after each run. \
+                 Each run produces a file named <run-id>.ndjson containing \
+                 newline-delimited JSON (NDJSON) — one event object per line. \
+                 Falls back to `traces_dir` in {config_path}, then \"traces\"."
+            ))
+        })
+        .mut_arg("json_logs", |a| {
+            a.help(format!(
+                "Emit logs as structured JSON instead of pretty-printed text. \
+                 Useful when piping output to a log aggregator or structured logging pipeline. \
+                 Falls back to `json_logs` in {config_path}."
+            ))
+        })
+        .get_matches();
+    let cli = Cli::from_arg_matches(&matches)?;
     let cfg = config::load()?;
 
     let json_logs = cli.json_logs || cfg.json_logs.unwrap_or(false);


### PR DESCRIPTION
## Summary

Adds persistent user configuration loaded from `~/.config/yaai/config.json5`, following the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/). This avoids config file clutter in home directories — the same convention used by tools like `gh`, `git`, `nvim`, and `bat`.

## Resolution order

CLI args **>** `~/.config/yaai/config.json5` **>** hardcoded defaults

## Config file

JSON5 is used instead of plain JSON so users can annotate their config with comments and write trailing commas — both common needs in a human-authored file.

```json5
{
  // default model for all runs
  "model": "openai/gpt-4o",
  "traces_dir": "~/.local/share/yaai/traces",
  "json_logs": false,
}
```

## Changes

- Add `config` (json5 feature) and `dirs` crates to workspace deps
- Add `apps/cli/src/config.rs` with `YaaiConfig` struct and `load()` fn
- `#[serde(deny_unknown_fields)]` ensures typos in the config fail loudly
- Make `--model` and `--traces-dir` CLI args optional (`Option<T>`)
- Add `PromptArgs::resolve()` for layered merge logic
- Wire config load and `json_logs` fallback into `main`
- Add 8 new tests covering config parsing, resolve priority layers, and JSON5 syntax