### PR TITLE
refactor(orchestrator): expose session memory to callers of run_single

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,6 +2885,7 @@ dependencies = [
  "vt100",
  "yaai-agent-loop",
  "yaai-llm",
+ "yaai-memory",
  "yaai-orchestrator",
  "yaai-tools",
  "yaai-tracer",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/main.rs"
 [dependencies]
 yaai-agent-loop = { path = "../../crates/agent-loop" }
 yaai-llm = { path = "../../crates/llm" }
+yaai-memory = { path = "../../crates/memory" }
 yaai-tools = { path = "../../crates/tools" }
 yaai-orchestrator = { path = "../../crates/orchestrator" }
 yaai-tracer = { path = "../../crates/tracer" }

--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -5,6 +5,7 @@ use tracing::info;
 use crate::config::{self, YaaiConfig};
 
 use super::runner::{run_prompt, ResolvedRunArgs};
+use yaai_memory::SessionMemory;
 
 fn expand_tilde(p: String) -> String {
     if let Some(rest) = p.strip_prefix("~/") {
@@ -95,7 +96,8 @@ pub async fn execute_non_interactive(args: &PromptArgs, cfg: &YaaiConfig) -> Res
         .prompt_text()?
         .ok_or_else(|| anyhow::anyhow!("prompt is required for non-interactive execution"))?;
     let resolved = args.resolve_run_args(cfg)?;
-    let result = run_prompt(&prompt, &resolved).await?;
+    let mut memory = SessionMemory::new();
+    let result = run_prompt(&prompt, &resolved, &mut memory).await?;
 
     info!(steps = result.steps_taken, "run complete");
     println!("{}", result.answer);

--- a/apps/cli/src/commands/runner.rs
+++ b/apps/cli/src/commands/runner.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use yaai_agent_loop::AgentConfig;
 use yaai_llm::LlmClient;
+use yaai_memory::SessionMemory;
 use yaai_orchestrator::run_single;
 use yaai_tools::ToolRegistry;
 
@@ -21,16 +22,21 @@ pub struct PromptRunResult {
     pub steps_taken: u32,
 }
 
-pub async fn run_prompt(prompt: &str, args: &ResolvedRunArgs) -> Result<PromptRunResult> {
+pub async fn run_prompt(
+    prompt: &str,
+    args: &ResolvedRunArgs,
+    memory: &mut SessionMemory,
+) -> Result<PromptRunResult> {
     let (provider, model) = parse_provider_model(&args.model)?;
     let llm = build_llm_client(&provider, &model)?;
-    run_prompt_with_client(prompt, args, llm.as_ref()).await
+    run_prompt_with_client(prompt, args, llm.as_ref(), memory).await
 }
 
 pub async fn run_prompt_with_client(
     prompt: &str,
     args: &ResolvedRunArgs,
     llm: &dyn LlmClient,
+    memory: &mut SessionMemory,
 ) -> Result<PromptRunResult> {
     let tools = ToolRegistry::new();
     let agent_config = AgentConfig {
@@ -39,7 +45,7 @@ pub async fn run_prompt_with_client(
         max_steps: DEFAULT_MAX_STEPS,
     };
 
-    let result = run_single(&agent_config, prompt, llm, &tools, &args.traces_dir).await?;
+    let result = run_single(&agent_config, prompt, memory, llm, &tools, &args.traces_dir).await?;
 
     Ok(PromptRunResult {
         answer: result.answer,
@@ -52,6 +58,7 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
     use yaai_llm::{LlmResponse, StubClient};
+    use yaai_memory::SessionMemory;
 
     #[tokio::test]
     async fn run_prompt_with_client_returns_answer_and_steps() {
@@ -61,8 +68,11 @@ mod tests {
             model: "openai/gpt-4o".to_string(),
             traces_dir: traces.path().display().to_string(),
         };
+        let mut memory = SessionMemory::new();
 
-        let result = run_prompt_with_client("hello", &args, &llm).await.unwrap();
+        let result = run_prompt_with_client("hello", &args, &llm, &mut memory)
+            .await
+            .unwrap();
 
         assert_eq!(result.answer, "final answer");
         assert_eq!(result.steps_taken, 1);

--- a/apps/cli/src/commands/tui/app.rs
+++ b/apps/cli/src/commands/tui/app.rs
@@ -54,19 +54,23 @@ impl TuiApp {
         run_result.and(restore_result)
     }
 
+    fn process_run_result(&mut self, result: RunResult) {
+        match result {
+            Ok((run_result, updated_memory)) => {
+                self.session_memory = updated_memory;
+                self.state.complete_run(Ok(run_result));
+            }
+            Err(e) => {
+                self.state.complete_run(Err(e));
+            }
+        }
+    }
+
     async fn event_loop(&mut self, terminal: &mut AppTerminal) -> Result<()> {
         let mut dirty = true;
         loop {
             while let Ok(result) = self.result_rx.try_recv() {
-                match result {
-                    Ok((run_result, updated_memory)) => {
-                        self.session_memory = updated_memory;
-                        self.state.complete_run(Ok(run_result));
-                    }
-                    Err(e) => {
-                        self.state.complete_run(Err(e));
-                    }
-                }
+                self.process_run_result(result);
                 dirty = true;
             }
 
@@ -401,13 +405,7 @@ mod tests {
             .unwrap();
 
         while let Ok(result) = app.result_rx.try_recv() {
-            match result {
-                Ok((run_result, updated_memory)) => {
-                    app.session_memory = updated_memory;
-                    app.state.complete_run(Ok(run_result));
-                }
-                Err(e) => app.state.complete_run(Err(e)),
-            }
+            app.process_run_result(result);
         }
 
         assert_eq!(app.state.run_state, RunState::Idle);
@@ -422,13 +420,7 @@ mod tests {
         app.result_tx.send(Err("boom".to_string())).unwrap();
 
         while let Ok(result) = app.result_rx.try_recv() {
-            match result {
-                Ok((run_result, updated_memory)) => {
-                    app.session_memory = updated_memory;
-                    app.state.complete_run(Ok(run_result));
-                }
-                Err(e) => app.state.complete_run(Err(e)),
-            }
+            app.process_run_result(result);
         }
 
         assert_eq!(app.state.run_state, RunState::Idle);

--- a/apps/cli/src/commands/tui/app.rs
+++ b/apps/cli/src/commands/tui/app.rs
@@ -11,6 +11,7 @@ use ratatui::{
 };
 use tokio::sync::mpsc;
 use tui_textarea::TextArea;
+use yaai_memory::SessionMemory;
 
 use crate::commands::runner::{run_prompt, PromptRunResult, ResolvedRunArgs};
 
@@ -18,12 +19,15 @@ use super::composer::{composer_height, new_composer};
 use super::state::{AppState, RunState};
 use super::terminal::{init_terminal, restore_terminal, AppTerminal};
 
+type RunResult = Result<(PromptRunResult, SessionMemory), String>;
+
 pub(crate) struct TuiApp {
     pub(crate) state: AppState,
     composer: TextArea<'static>,
     run_args: ResolvedRunArgs,
-    result_rx: mpsc::UnboundedReceiver<Result<PromptRunResult, String>>,
-    result_tx: mpsc::UnboundedSender<Result<PromptRunResult, String>>,
+    pub(crate) session_memory: SessionMemory,
+    result_rx: mpsc::UnboundedReceiver<RunResult>,
+    result_tx: mpsc::UnboundedSender<RunResult>,
     active_task: Option<tokio::task::JoinHandle<()>>,
 }
 
@@ -35,6 +39,7 @@ impl TuiApp {
             state: AppState::default(),
             composer: new_composer(),
             run_args,
+            session_memory: SessionMemory::new(),
             result_rx,
             result_tx,
             active_task: None,
@@ -53,7 +58,15 @@ impl TuiApp {
         let mut dirty = true;
         loop {
             while let Ok(result) = self.result_rx.try_recv() {
-                self.state.complete_run(result);
+                match result {
+                    Ok((run_result, updated_memory)) => {
+                        self.session_memory = updated_memory;
+                        self.state.complete_run(Ok(run_result));
+                    }
+                    Err(e) => {
+                        self.state.complete_run(Err(e));
+                    }
+                }
                 dirty = true;
             }
 
@@ -109,14 +122,18 @@ impl TuiApp {
         self.composer = new_composer();
         let tx = self.result_tx.clone();
         let run_args = self.run_args.clone();
+        let memory_snapshot = self.session_memory.clone();
 
         if let Some(old) = self.active_task.take() {
             old.abort();
         }
+        while self.result_rx.try_recv().is_ok() {}
         let handle = tokio::spawn(async move {
-            let result = run_prompt(&input, &run_args)
+            let mut memory = memory_snapshot;
+            let result = run_prompt(&input, &run_args, &mut memory)
                 .await
-                .map_err(|err| err.to_string());
+                .map(|r| (r, memory))
+                .map_err(|e| e.to_string());
             let _ = tx.send(result);
         });
         self.active_task = Some(handle);
@@ -172,6 +189,7 @@ impl TuiApp {
 #[cfg(test)]
 mod tests {
     use crossterm::event::{KeyEvent, KeyEventKind, KeyEventState};
+    use yaai_memory::SessionMemory;
 
     use crate::commands::runner::PromptRunResult;
 
@@ -373,14 +391,23 @@ mod tests {
         app.state.start_run("test");
 
         app.result_tx
-            .send(Ok(PromptRunResult {
-                answer: "done".to_string(),
-                steps_taken: 3,
-            }))
+            .send(Ok((
+                PromptRunResult {
+                    answer: "done".to_string(),
+                    steps_taken: 3,
+                },
+                SessionMemory::new(),
+            )))
             .unwrap();
 
         while let Ok(result) = app.result_rx.try_recv() {
-            app.state.complete_run(result);
+            match result {
+                Ok((run_result, updated_memory)) => {
+                    app.session_memory = updated_memory;
+                    app.state.complete_run(Ok(run_result));
+                }
+                Err(e) => app.state.complete_run(Err(e)),
+            }
         }
 
         assert_eq!(app.state.run_state, RunState::Idle);
@@ -395,7 +422,13 @@ mod tests {
         app.result_tx.send(Err("boom".to_string())).unwrap();
 
         while let Ok(result) = app.result_rx.try_recv() {
-            app.state.complete_run(result);
+            match result {
+                Ok((run_result, updated_memory)) => {
+                    app.session_memory = updated_memory;
+                    app.state.complete_run(Ok(run_result));
+                }
+                Err(e) => app.state.complete_run(Err(e)),
+            }
         }
 
         assert_eq!(app.state.run_state, RunState::Idle);

--- a/crates/orchestrator/src/single.rs
+++ b/crates/orchestrator/src/single.rs
@@ -7,17 +7,20 @@ use yaai_tools::ToolRegistry;
 use yaai_tracer::Tracer;
 
 /// Run a single agent on a task, flush the trace, and return the result.
+///
+/// The caller owns `memory` — pass a fresh [`SessionMemory`] for a stateless
+/// run, or a persistent one for multi-turn conversation.
 pub async fn run_single(
     config: &AgentConfig,
     task: impl Into<String>,
+    memory: &mut SessionMemory,
     llm: &dyn LlmClient,
     tools: &ToolRegistry,
     traces_dir: &str,
 ) -> Result<AgentResult> {
     let tracer = Tracer::new(Uuid::new_v4(), traces_dir)?;
-    let mut memory = SessionMemory::new();
 
-    let result = AgentRunner::new(config, llm, tools, &tracer, &mut memory)
+    let result = AgentRunner::new(config, llm, tools, &tracer, memory)
         .run(task)
         .await;
 

--- a/crates/orchestrator/tests/single.rs
+++ b/crates/orchestrator/tests/single.rs
@@ -1,5 +1,6 @@
 use yaai_agent_loop::AgentConfig;
 use yaai_llm::{LlmResponse, StubClient};
+use yaai_memory::SessionMemory;
 use yaai_orchestrator::run_single;
 use yaai_tools::ToolRegistry;
 
@@ -16,10 +17,12 @@ async fn single_agent_completes() {
     let llm = StubClient::new(vec![LlmResponse::text("final answer")]);
     let tools = ToolRegistry::new();
     let dir = tempfile::tempdir().unwrap();
+    let mut memory = SessionMemory::new();
 
     let result = run_single(
         &cfg("solo"),
         "do a task",
+        &mut memory,
         &llm,
         &tools,
         dir.path().to_str().unwrap(),
@@ -36,10 +39,12 @@ async fn single_agent_closes_tracer_on_error() {
     let llm = StubClient::new(vec![]);
     let tools = ToolRegistry::new();
     let dir = tempfile::tempdir().unwrap();
+    let mut memory = SessionMemory::new();
 
     let err = run_single(
         &cfg("solo"),
         "do a task",
+        &mut memory,
         &llm,
         &tools,
         dir.path().to_str().unwrap(),


### PR DESCRIPTION
Make `SessionMemory` caller-owned in `run_single` so callers can persist context across turns. Thread the memory through the CLI runner, prompt command, and TUI app.

## Before - No memory

![yaai-no-memory](https://github.com/user-attachments/assets/47e25689-c7db-45e7-81f9-7d130f12e916)

## After - with memory

![yaai-memory](https://github.com/user-attachments/assets/34d9e68b-e6ec-4a15-b085-9120f69a7b86)
