### PR TITLE
refactor(agent-loop): replace `&mut SessionMemory` with owned builder pattern

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2882,6 +2882,7 @@ dependencies = [
  "tracing",
  "tui-textarea",
  "unicode-width 0.2.0",
+ "uuid",
  "vt100",
  "yaai-agent-loop",
  "yaai-llm",

--- a/apps/cli/Cargo.toml
+++ b/apps/cli/Cargo.toml
@@ -26,6 +26,7 @@ tracing = { workspace = true }
 tokio = { workspace = true }
 tui-textarea = { workspace = true }
 unicode-width = { workspace = true }
+uuid = { workspace = true }
 
 [dev-dependencies]
 portable-pty = { workspace = true }

--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -96,8 +96,7 @@ pub async fn execute_non_interactive(args: &PromptArgs, cfg: &YaaiConfig) -> Res
         .prompt_text()?
         .ok_or_else(|| anyhow::anyhow!("prompt is required for non-interactive execution"))?;
     let resolved = args.resolve_run_args(cfg)?;
-    let mut memory = SessionMemory::new();
-    let result = run_prompt(&prompt, &resolved, &mut memory).await?;
+    let (result, _memory) = run_prompt(&prompt, &resolved, SessionMemory::new()).await?;
 
     info!(steps = result.steps_taken, "run complete");
     println!("{}", result.answer);

--- a/apps/cli/src/commands/runner.rs
+++ b/apps/cli/src/commands/runner.rs
@@ -1,9 +1,10 @@
-use anyhow::Result;
-use yaai_agent_loop::AgentConfig;
+use anyhow::{Context, Result};
+use uuid::Uuid;
+use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::LlmClient;
 use yaai_memory::SessionMemory;
-use yaai_orchestrator::run_single;
 use yaai_tools::ToolRegistry;
+use yaai_tracer::Tracer;
 
 use super::llm::{build_llm_client, parse_provider_model};
 
@@ -25,32 +26,54 @@ pub struct PromptRunResult {
 pub async fn run_prompt(
     prompt: &str,
     args: &ResolvedRunArgs,
-    memory: &mut SessionMemory,
-) -> Result<PromptRunResult> {
+    initial_memory: SessionMemory,
+) -> Result<(PromptRunResult, SessionMemory)> {
     let (provider, model) = parse_provider_model(&args.model)?;
     let llm = build_llm_client(&provider, &model)?;
-    run_prompt_with_client(prompt, args, llm.as_ref(), memory).await
+    run_prompt_with_client(prompt, args, llm.as_ref(), initial_memory).await
 }
 
+/// Run a prompt, returning the result and the updated conversation history.
+///
+/// Pass a fresh [`SessionMemory`] for a stateless run, or a snapshot from a
+/// previous result for multi-turn conversation.
 pub async fn run_prompt_with_client(
     prompt: &str,
     args: &ResolvedRunArgs,
     llm: &dyn LlmClient,
-    memory: &mut SessionMemory,
-) -> Result<PromptRunResult> {
+    initial_memory: SessionMemory,
+) -> Result<(PromptRunResult, SessionMemory)> {
     let tools = ToolRegistry::new();
     let agent_config = AgentConfig {
         id: "prompt".to_string(),
         system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
         max_steps: DEFAULT_MAX_STEPS,
     };
+    let tracer = Tracer::new(Uuid::new_v4(), &args.traces_dir)?;
 
-    let result = run_single(&agent_config, prompt, memory, llm, &tools, &args.traces_dir).await?;
+    let agent_result = AgentRunner::new(&agent_config, llm, &tools, &tracer)
+        .with_memory(initial_memory)
+        .run(prompt)
+        .await;
 
-    Ok(PromptRunResult {
-        answer: result.answer,
-        steps_taken: result.steps_taken,
-    })
+    let close_result = tracer.close().await;
+
+    let agent_result = match (agent_result, close_result) {
+        (Ok(r), Ok(())) => Ok(r),
+        (Err(run_err), Ok(())) => Err(run_err),
+        (Ok(_), Err(close_err)) => Err(close_err),
+        (Err(run_err), Err(close_err)) => {
+            Err(run_err).context(format!("failed to close tracer cleanly: {close_err}"))
+        }
+    }?;
+
+    Ok((
+        PromptRunResult {
+            answer: agent_result.answer,
+            steps_taken: agent_result.steps_taken,
+        },
+        agent_result.memory,
+    ))
 }
 
 #[cfg(test)]
@@ -58,7 +81,6 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
     use yaai_llm::{LlmResponse, StubClient};
-    use yaai_memory::SessionMemory;
 
     #[tokio::test]
     async fn run_prompt_with_client_returns_answer_and_steps() {
@@ -68,9 +90,8 @@ mod tests {
             model: "openai/gpt-4o".to_string(),
             traces_dir: traces.path().display().to_string(),
         };
-        let mut memory = SessionMemory::new();
 
-        let result = run_prompt_with_client("hello", &args, &llm, &mut memory)
+        let (result, _memory) = run_prompt_with_client("hello", &args, &llm, SessionMemory::new())
             .await
             .unwrap();
 

--- a/apps/cli/src/commands/tui/app.rs
+++ b/apps/cli/src/commands/tui/app.rs
@@ -133,10 +133,8 @@ impl TuiApp {
         }
         while self.result_rx.try_recv().is_ok() {}
         let handle = tokio::spawn(async move {
-            let mut memory = memory_snapshot;
-            let result = run_prompt(&input, &run_args, &mut memory)
+            let result = run_prompt(&input, &run_args, memory_snapshot)
                 .await
-                .map(|r| (r, memory))
                 .map_err(|e| e.to_string());
             let _ = tx.send(result);
         });

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -32,6 +32,10 @@ pub struct AgentResult {
     pub answer: String,
     /// Number of loop iterations consumed.
     pub steps_taken: u32,
+    /// Final conversation history. Skipped during serialisation to keep
+    /// the JSON output lean; inspect it directly when testing or introspecting.
+    #[serde(skip)]
+    pub memory: SessionMemory,
 }
 
 /// Drives an agent through its ReAct execution loop.
@@ -40,7 +44,7 @@ pub struct AgentRunner<'a> {
     llm: &'a dyn LlmClient,
     tools: &'a ToolRegistry,
     tracer: &'a Tracer,
-    memory: &'a mut SessionMemory,
+    memory: SessionMemory,
 }
 
 impl<'a> AgentRunner<'a> {
@@ -49,23 +53,34 @@ impl<'a> AgentRunner<'a> {
         llm: &'a dyn LlmClient,
         tools: &'a ToolRegistry,
         tracer: &'a Tracer,
-        memory: &'a mut SessionMemory,
     ) -> Self {
         Self {
             config,
             llm,
             tools,
             tracer,
-            memory,
+            memory: SessionMemory::new(),
         }
+    }
+
+    /// Seed the runner with existing conversation history.
+    ///
+    /// Use this for multi-turn conversations where the history from a previous
+    /// run should be carried forward. For a fresh, stateless run, omit this call.
+    pub fn with_memory(self, memory: SessionMemory) -> Self {
+        Self { memory, ..self }
     }
 
     /// Run the agent loop on the given task, returning the final answer.
     ///
+    /// Consumes the runner. The returned [`AgentResult`] includes the final
+    /// conversation history so callers can inspect it without holding a separate
+    /// mutable reference throughout the run.
+    ///
     /// The caller is responsible for calling [`Tracer::close`] on the tracer
     /// after this method returns (success or error) to shut down the background
     /// writer task cleanly.
-    pub async fn run(&mut self, task: impl Into<String>) -> Result<AgentResult> {
+    pub async fn run(mut self, task: impl Into<String>) -> Result<AgentResult> {
         let task = task.into();
         let run_id = self.tracer.run_id();
 
@@ -170,6 +185,7 @@ impl<'a> AgentRunner<'a> {
                     agent_id: self.config.id.clone(),
                     answer,
                     steps_taken: step + 1,
+                    memory: self.memory,
                 });
             }
         }

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -3,7 +3,6 @@ use tempfile::{NamedTempFile, TempDir};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::{LlmResponse, StubClient};
-use yaai_memory::SessionMemory;
 use yaai_tools::{builtin::ReadTool, ToolRegistry};
 use yaai_tracer::Tracer;
 
@@ -32,10 +31,9 @@ fn temp_file_path() -> (NamedTempFile, String) {
 async fn produces_final_answer_without_tools() {
     let llm = StubClient::new(vec![LlmResponse::text("The answer is 42.")]);
     let tools = ToolRegistry::new();
-    let mut mem = SessionMemory::new();
     let (_tmp, tr) = tracer();
 
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
         .run("What is the answer?")
         .await
         .unwrap();
@@ -52,12 +50,10 @@ async fn calls_tool_then_answers() {
         LlmResponse::tool("read", serde_json::json!({"file_path": path})),
         LlmResponse::text("The answer is 42."),
     ]);
-    let mut tools = ToolRegistry::new();
-    tools.register(ReadTool::new());
-    let mut mem = SessionMemory::new();
+    let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
         .run("Read the file")
         .await
         .unwrap();
@@ -75,12 +71,10 @@ async fn respects_max_steps() {
         LlmResponse::tool("read", serde_json::json!({"file_path": path.clone()})),
         LlmResponse::tool("read", serde_json::json!({"file_path": path})),
     ]);
-    let mut tools = ToolRegistry::new();
-    tools.register(ReadTool::new());
-    let mut mem = SessionMemory::new();
+    let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
-    let err = AgentRunner::new(&cfg(3), &llm, &tools, &tr, &mut mem)
+    let err = AgentRunner::new(&cfg(3), &llm, &tools, &tr)
         .run("loop forever")
         .await
         .unwrap_err();
@@ -96,14 +90,12 @@ async fn trace_has_correct_event_sequence() {
         LlmResponse::tool("read", serde_json::json!({"file_path": path})),
         LlmResponse::text("Result is done."),
     ]);
-    let mut tools = ToolRegistry::new();
-    tools.register(ReadTool::new());
-    let mut mem = SessionMemory::new();
+    let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
     // Tracer is write-only (streams to ndjson); verify the run completed with
     // the expected step count as a proxy for correct event sequencing.
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
         .run("Read file")
         .await
         .unwrap();
@@ -121,18 +113,16 @@ async fn memory_accumulates_across_steps() {
         LlmResponse::tool("read", serde_json::json!({"file_path": path})),
         LlmResponse::text("Done."),
     ]);
-    let mut tools = ToolRegistry::new();
-    tools.register(ReadTool::new());
-    let mut mem = SessionMemory::new();
+    let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
-    AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
         .run("task")
         .await
         .unwrap();
 
     // user task + tool result observation + final assistant = at least 3
-    assert!(mem.len() >= 3);
+    assert!(result.memory.len() >= 3);
     tr.close().await.unwrap();
 }
 
@@ -145,15 +135,13 @@ async fn graceful_tool_error_continues_loop() {
         ),
         LlmResponse::text("Handled the error."),
     ]);
-    let mut tools = ToolRegistry::new();
-    tools.register(ReadTool::new());
-    let mut mem = SessionMemory::new();
+    let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
     // The tool error should be fed back as a ToolResult observation and the
     // loop should continue to the next LLM call rather than propagating the
     // error up to the caller.
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
         .run("read missing file")
         .await
         .unwrap();
@@ -171,10 +159,9 @@ async fn empty_llm_response_returns_error() {
         tool_call: None,
     }]);
     let tools = ToolRegistry::new();
-    let mut mem = SessionMemory::new();
     let (_tmp, tr) = tracer();
 
-    let err = AgentRunner::new(&cfg(5), &llm, &tools, &tr, &mut mem)
+    let err = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
         .run("task")
         .await
         .unwrap_err();
@@ -202,6 +189,7 @@ fn agent_config_serde_round_trip() {
         agent_id: "agent-1".to_string(),
         answer: "42".to_string(),
         steps_taken: 3,
+        memory: Default::default(),
     };
     let json = serde_json::to_string(&result).unwrap();
     let r2: AgentResult = serde_json::from_str(&json).unwrap();

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -79,12 +79,12 @@ impl LlmClient for OpenAiClient {
         debug!(model = %self.model, messages = messages.len(), "calling OpenAI");
 
         // OpenAI expects the system prompt as the first entry in the messages array.
-        let mut full_messages;
+        let prepended: Vec<Message>;
         let messages = if let Some(sys) = system {
-            full_messages = Vec::with_capacity(messages.len() + 1);
-            full_messages.push(Message::system(sys));
-            full_messages.extend_from_slice(messages);
-            full_messages.as_slice()
+            prepended = std::iter::once(Message::system(sys))
+                .chain(messages.iter().cloned())
+                .collect();
+            prepended.as_slice()
         } else {
             messages
         };

--- a/crates/llm/src/stub.rs
+++ b/crates/llm/src/stub.rs
@@ -4,22 +4,24 @@
 //! It returns an error if the script is exhausted, which signals that the
 //! agent ran more steps than the test anticipated.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
-use tokio::sync::Mutex;
 
 use crate::{LlmClient, LlmResponse, Message};
 
 pub struct StubClient {
-    script: Mutex<Vec<LlmResponse>>,
+    responses: Vec<LlmResponse>,
+    index: AtomicUsize,
 }
 
 impl StubClient {
     /// Create a stub with a sequence of responses (first element = first returned).
-    pub fn new(mut responses: Vec<LlmResponse>) -> Self {
-        responses.reverse(); // pop() from the end returns in original order
+    pub fn new(responses: Vec<LlmResponse>) -> Self {
         Self {
-            script: Mutex::new(responses),
+            responses,
+            index: AtomicUsize::new(0),
         }
     }
 }
@@ -27,7 +29,8 @@ impl StubClient {
 #[async_trait]
 impl LlmClient for StubClient {
     async fn complete(&self, _system: Option<&str>, _messages: &[Message]) -> Result<LlmResponse> {
-        self.script.lock().await.pop().ok_or_else(|| {
+        let i = self.index.fetch_add(1, Ordering::SeqCst);
+        self.responses.get(i).cloned().ok_or_else(|| {
             anyhow!("StubClient script exhausted — agent ran more steps than expected")
         })
     }

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -81,11 +81,6 @@ impl SessionMemory {
     pub fn is_empty(&self) -> bool {
         self.entries.is_empty()
     }
-
-    /// Remove all entries.
-    pub fn clear(&mut self) {
-        self.entries.clear();
-    }
 }
 
 #[cfg(test)]
@@ -118,15 +113,6 @@ mod tests {
     fn is_empty_on_new() {
         assert!(SessionMemory::new().is_empty());
     }
-
-    #[test]
-    fn clear_empties_memory() {
-        let mut mem = SessionMemory::new();
-        mem.add(Role::User, "hello");
-        mem.clear();
-        assert!(mem.is_empty());
-    }
-
     #[test]
     fn role_serde_round_trip() {
         for (role, expected) in [

--- a/crates/orchestrator/src/single.rs
+++ b/crates/orchestrator/src/single.rs
@@ -2,25 +2,20 @@ use anyhow::{Context, Result};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentResult, AgentRunner};
 use yaai_llm::LlmClient;
-use yaai_memory::SessionMemory;
 use yaai_tools::ToolRegistry;
 use yaai_tracer::Tracer;
 
 /// Run a single agent on a task, flush the trace, and return the result.
-///
-/// The caller owns `memory` — pass a fresh [`SessionMemory`] for a stateless
-/// run, or a persistent one for multi-turn conversation.
 pub async fn run_single(
     config: &AgentConfig,
     task: impl Into<String>,
-    memory: &mut SessionMemory,
     llm: &dyn LlmClient,
     tools: &ToolRegistry,
     traces_dir: &str,
 ) -> Result<AgentResult> {
     let tracer = Tracer::new(Uuid::new_v4(), traces_dir)?;
 
-    let result = AgentRunner::new(config, llm, tools, &tracer, memory)
+    let result = AgentRunner::new(config, llm, tools, &tracer)
         .run(task)
         .await;
 

--- a/crates/orchestrator/tests/single.rs
+++ b/crates/orchestrator/tests/single.rs
@@ -1,6 +1,5 @@
 use yaai_agent_loop::AgentConfig;
 use yaai_llm::{LlmResponse, StubClient};
-use yaai_memory::SessionMemory;
 use yaai_orchestrator::run_single;
 use yaai_tools::ToolRegistry;
 
@@ -17,12 +16,10 @@ async fn single_agent_completes() {
     let llm = StubClient::new(vec![LlmResponse::text("final answer")]);
     let tools = ToolRegistry::new();
     let dir = tempfile::tempdir().unwrap();
-    let mut memory = SessionMemory::new();
 
     let result = run_single(
         &cfg("solo"),
         "do a task",
-        &mut memory,
         &llm,
         &tools,
         dir.path().to_str().unwrap(),
@@ -39,12 +36,10 @@ async fn single_agent_closes_tracer_on_error() {
     let llm = StubClient::new(vec![]);
     let tools = ToolRegistry::new();
     let dir = tempfile::tempdir().unwrap();
-    let mut memory = SessionMemory::new();
 
     let err = run_single(
         &cfg("solo"),
         "do a task",
-        &mut memory,
         &llm,
         &tools,
         dir.path().to_str().unwrap(),

--- a/crates/tools/src/builtin/read.rs
+++ b/crates/tools/src/builtin/read.rs
@@ -1,11 +1,36 @@
 use crate::{Tool, ToolError};
 use async_trait::async_trait;
+use serde::Serialize;
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader};
 
 const DEFAULT_LIMIT: usize = 2000;
 const MAX_BYTES: usize = 512 * 1024; // 512 KB
 const BINARY_SAMPLE_BYTES: usize = 8192;
+
+/// The `lines` range returned inside a [`ReadResult`].
+#[derive(Debug, Serialize)]
+struct LineRange {
+    from: usize,
+    to: usize,
+    total: usize,
+}
+
+/// The serialised response of the `read` tool.
+///
+/// `continuation` is omitted from the JSON entirely when `None`, which lets
+/// callers reliably test for absence rather than having to distinguish `null`
+/// from a missing key.
+#[derive(Debug, Serialize)]
+struct ReadResult<'a> {
+    path: &'a str,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    lines: LineRange,
+    content: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    continuation: Option<String>,
+}
 
 /// Reads a file and returns its contents with line numbers.
 ///
@@ -199,28 +224,28 @@ impl Tool for ReadTool {
         };
         let is_truncated = actual_end < total_lines;
 
-        let mut result = serde_json::json!({
-            "path": file_path,
-            "type": "file",
-            "lines": {
-                "from": from_line,
-                "to": to_line,
-                "total": total_lines
+        let content = output.trim_end_matches('\n');
+        let result = ReadResult {
+            path: file_path,
+            kind: "file",
+            lines: LineRange {
+                from: from_line,
+                to: to_line,
+                total: total_lines,
             },
-            "content": output.trim_end_matches('\n')
-        });
+            content,
+            continuation: is_truncated.then(|| {
+                format!(
+                    "Showing lines {}-{} of {}. Use offset={} to continue reading.",
+                    from_line,
+                    to_line,
+                    total_lines,
+                    actual_end + 1,
+                )
+            }),
+        };
 
-        if is_truncated {
-            result["continuation"] = Value::String(format!(
-                "Showing lines {}-{} of {}. Use offset={} to continue reading.",
-                from_line,
-                to_line,
-                total_lines,
-                actual_end + 1
-            ));
-        }
-
-        Ok(result)
+        Ok(serde_json::to_value(result).expect("ReadResult is always serializable"))
     }
 }
 
@@ -236,14 +261,11 @@ mod tests {
     use tempfile::NamedTempFile;
 
     fn make_input(path: &str, offset: Option<u64>, limit: Option<u64>) -> Value {
-        let mut map = serde_json::json!({ "file_path": path });
-        if let Some(o) = offset {
-            map["offset"] = Value::Number(o.into());
-        }
-        if let Some(l) = limit {
-            map["limit"] = Value::Number(l.into());
-        }
-        map
+        serde_json::json!({
+            "file_path": path,
+            "offset": offset,
+            "limit": limit,
+        })
     }
 
     #[tokio::test]

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -54,9 +54,10 @@ impl ToolRegistry {
         Self::default()
     }
 
-    /// Register a tool.
-    pub fn register(&mut self, tool: impl Tool + 'static) {
+    /// Register a tool, returning `self` to allow chaining.
+    pub fn register(mut self, tool: impl Tool + 'static) -> Self {
         self.tools.push(Box::new(tool));
+        self
     }
 
     /// Names of all registered tools.

--- a/crates/tools/tests/registry_tests.rs
+++ b/crates/tools/tests/registry_tests.rs
@@ -35,8 +35,7 @@ fn tool_error_execution_failed_display() {
 
 #[test]
 fn lists_registered_tools() {
-    let mut r = ToolRegistry::new();
-    r.register(ReadTool::new());
+    let r = ToolRegistry::new().register(ReadTool::new());
     assert!(r.names().contains(&"read"));
 }
 
@@ -52,8 +51,7 @@ async fn dispatch_unknown_tool_returns_not_found() {
 
 #[tokio::test]
 async fn dispatch_missing_required_field_returns_invalid_input() {
-    let mut registry = ToolRegistry::new();
-    registry.register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::new());
 
     match registry.dispatch("read", serde_json::json!({})).await {
         Err(ToolError::InvalidInput { name, reason }) => {
@@ -66,8 +64,7 @@ async fn dispatch_missing_required_field_returns_invalid_input() {
 
 #[tokio::test]
 async fn dispatch_null_required_field_returns_invalid_input() {
-    let mut registry = ToolRegistry::new();
-    registry.register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::new());
 
     match registry
         .dispatch("read", serde_json::json!({ "file_path": null }))
@@ -82,8 +79,7 @@ async fn dispatch_null_required_field_returns_invalid_input() {
 
 #[test]
 fn descriptions_anthropic_uses_input_schema_key() {
-    let mut registry = ToolRegistry::new();
-    registry.register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::new());
 
     let descs = registry.descriptions(ToolSchemaFormat::Anthropic);
     assert_eq!(descs.len(), 1);
@@ -96,8 +92,7 @@ fn descriptions_anthropic_uses_input_schema_key() {
 
 #[test]
 fn descriptions_openai_uses_function_parameters_key() {
-    let mut registry = ToolRegistry::new();
-    registry.register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::new());
 
     let descs = registry.descriptions(ToolSchemaFormat::OpenAi);
     assert_eq!(descs.len(), 1);
@@ -116,8 +111,7 @@ async fn dispatch_read_returns_file_contents() {
     writeln!(f, "line one").unwrap();
     writeln!(f, "line two").unwrap();
 
-    let mut registry = ToolRegistry::new();
-    registry.register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::new());
 
     let result = registry
         .dispatch(
@@ -136,8 +130,7 @@ async fn dispatch_read_returns_file_contents() {
 
 #[tokio::test]
 async fn dispatch_read_missing_file_returns_execution_failed() {
-    let mut registry = ToolRegistry::new();
-    registry.register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::new());
 
     match registry
         .dispatch(

--- a/crates/tracer/src/lib.rs
+++ b/crates/tracer/src/lib.rs
@@ -171,8 +171,10 @@ async fn writer_task(path: PathBuf, mut rx: mpsc::UnboundedReceiver<WriterMsg>) 
     while let Some(msg) = rx.recv().await {
         match msg {
             WriterMsg::Event(event) => {
-                let mut line = serde_json::to_string(&event).context("serialising trace event")?;
-                line.push('\n');
+                let line = format!(
+                    "{}\n",
+                    serde_json::to_string(&event).context("serialising trace event")?
+                );
                 file.write_all(line.as_bytes())
                     .await
                     .with_context(|| format!("writing to {}", path.display()))?;


### PR DESCRIPTION
## Summary

I hadn't focused on mutations, so taking there chance now to replace as mutations with immutable architecture. Replace the mutable-reference-based `SessionMemory` API with an owned, builder-style one across the full agent stack.

### `yaai-agent-loop`
- `AgentRunner::new()` no longer takes `&mut SessionMemory`; use `with_memory()` builder for multi-turn runs
- `AgentRunner::run()` consumes `self` and returns memory inside `AgentResult`
- `AgentResult` gains a `memory` field (skipped in JSON serialisation)

### `yaai-tools`
- `ToolRegistry::register()` returns `Self` for fluent chaining

### `yaai-llm`
- `StubClient` replaces `Mutex<Vec<LlmResponse>>` with `AtomicUsize` index

### `yaai-memory`
- Remove `SessionMemory::clear()` — unused after ownership shift

### `yaai-orchestrator`
- `run_single()` drops its `memory` parameter

### `apps/cli`
- `run_prompt` / `run_prompt_with_client` take and return owned `SessionMemory`
- `ReadTool` output serialised via typed structs instead of ad-hoc JSON macros