### PR TITLE
feat(llm): wire native tool calling with typed schemas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,6 +432,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,6 +1577,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1648,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2956,6 +2997,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "schemars",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
+schemars = "0.8"
 
 # Error handling
 anyhow = "1"

--- a/apps/cli/src/commands/runner.rs
+++ b/apps/cli/src/commands/runner.rs
@@ -133,5 +133,42 @@ mod tests {
         assert_eq!(result.answer, "final answer");
         assert_eq!(result.steps_taken, 1);
     }
+
+    #[tokio::test]
+    async fn run_prompt_with_client_propagates_agent_error() {
+        let llm = StubClient::new(vec![]);
+        let traces = tempdir().unwrap();
+        let args = ResolvedRunArgs {
+            model: "openai/gpt-4o".to_string(),
+            traces_dir: traces.path().display().to_string(),
+        };
+
+        let err = run_prompt_with_client(
+            "hello",
+            &args,
+            &llm,
+            SessionMemory::new(),
+            ToolSchemaFormat::OpenAi,
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("StubClient script exhausted"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn run_prompt_fails_on_invalid_provider_model() {
+        let args = ResolvedRunArgs {
+            model: "bogus/model".to_string(),
+            traces_dir: tempdir().unwrap().path().display().to_string(),
+        };
+        let err = run_prompt("hi", &args, SessionMemory::new())
+            .await
+            .unwrap_err();
+        assert!(err.to_string().to_lowercase().contains("provider"));
+    }
 }
 // grcov-excl-stop

--- a/apps/cli/src/commands/runner.rs
+++ b/apps/cli/src/commands/runner.rs
@@ -3,12 +3,13 @@ use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::LlmClient;
 use yaai_memory::SessionMemory;
-use yaai_tools::ToolRegistry;
+use yaai_tools::{ReadTool, ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::Tracer;
 
-use super::llm::{build_llm_client, parse_provider_model};
+use super::llm::{build_llm_client, parse_provider_model, Provider};
 
-pub const DEFAULT_SYSTEM_PROMPT: &str = "You are a helpful assistant.";
+pub const DEFAULT_SYSTEM_PROMPT: &str = "You are a helpful assistant with access to tools. \
+    Use the `read` tool with an absolute path to read files from the filesystem.";
 pub const DEFAULT_MAX_STEPS: u32 = 10;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,7 +31,15 @@ pub async fn run_prompt(
 ) -> Result<(PromptRunResult, SessionMemory)> {
     let (provider, model) = parse_provider_model(&args.model)?;
     let llm = build_llm_client(&provider, &model)?;
-    run_prompt_with_client(prompt, args, llm.as_ref(), initial_memory).await
+    let tool_format = match provider {
+        Provider::OpenAi => ToolSchemaFormat::OpenAi,
+        Provider::Anthropic => ToolSchemaFormat::Anthropic,
+    };
+    run_prompt_with_client(prompt, args, llm.as_ref(), initial_memory, tool_format).await
+}
+
+pub fn build_tool_registry() -> ToolRegistry {
+    ToolRegistry::new().register(ReadTool::new())
 }
 
 /// Run a prompt, returning the result and the updated conversation history.
@@ -42,16 +51,26 @@ pub async fn run_prompt_with_client(
     args: &ResolvedRunArgs,
     llm: &dyn LlmClient,
     initial_memory: SessionMemory,
+    tool_format: ToolSchemaFormat,
 ) -> Result<(PromptRunResult, SessionMemory)> {
-    let tools = ToolRegistry::new();
+    let tools = build_tool_registry();
+
+    let cwd = std::env::current_dir()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    let system_prompt = if cwd.is_empty() {
+        DEFAULT_SYSTEM_PROMPT.to_string()
+    } else {
+        format!("{}\nWorking directory: {}", DEFAULT_SYSTEM_PROMPT, cwd)
+    };
     let agent_config = AgentConfig {
         id: "prompt".to_string(),
-        system_prompt: DEFAULT_SYSTEM_PROMPT.to_string(),
+        system_prompt,
         max_steps: DEFAULT_MAX_STEPS,
     };
     let tracer = Tracer::new(Uuid::new_v4(), &args.traces_dir)?;
 
-    let agent_result = AgentRunner::new(&agent_config, llm, &tools, &tracer)
+    let agent_result = AgentRunner::new(&agent_config, llm, &tools, &tracer, tool_format)
         .with_memory(initial_memory)
         .run(prompt)
         .await;
@@ -83,6 +102,15 @@ mod tests {
     use tempfile::tempdir;
     use yaai_llm::{LlmResponse, StubClient};
 
+    #[test]
+    fn build_tool_registry_includes_read_tool() {
+        let registry = build_tool_registry();
+        assert!(
+            registry.names().contains(&"read"),
+            "expected 'read' tool to be registered"
+        );
+    }
+
     #[tokio::test]
     async fn run_prompt_with_client_returns_answer_and_steps() {
         let llm = StubClient::new(vec![LlmResponse::text("final answer")]);
@@ -92,9 +120,15 @@ mod tests {
             traces_dir: traces.path().display().to_string(),
         };
 
-        let (result, _memory) = run_prompt_with_client("hello", &args, &llm, SessionMemory::new())
-            .await
-            .unwrap();
+        let (result, _memory) = run_prompt_with_client(
+            "hello",
+            &args,
+            &llm,
+            SessionMemory::new(),
+            ToolSchemaFormat::OpenAi,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(result.answer, "final answer");
         assert_eq!(result.steps_taken, 1);

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -7,9 +7,9 @@ use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use tracing::{info, warn};
 use uuid::Uuid;
-use yaai_llm::{LlmClient, Message};
-use yaai_memory::{Role, SessionMemory};
-use yaai_tools::ToolRegistry;
+use yaai_llm::{ConversationTurn, LlmClient, Message};
+use yaai_memory::{EntryContent, Role, SessionMemory};
+use yaai_tools::{ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::{EventKind, Tracer};
 
 /// Configuration for a single agent instance.
@@ -45,6 +45,7 @@ pub struct AgentRunner<'a> {
     tools: &'a ToolRegistry,
     tracer: &'a Tracer,
     memory: SessionMemory,
+    tool_format: ToolSchemaFormat,
 }
 
 impl<'a> AgentRunner<'a> {
@@ -53,6 +54,7 @@ impl<'a> AgentRunner<'a> {
         llm: &'a dyn LlmClient,
         tools: &'a ToolRegistry,
         tracer: &'a Tracer,
+        tool_format: ToolSchemaFormat,
     ) -> Self {
         Self {
             config,
@@ -60,6 +62,7 @@ impl<'a> AgentRunner<'a> {
             tools,
             tracer,
             memory: SessionMemory::new(),
+            tool_format,
         }
     }
 
@@ -88,20 +91,35 @@ impl<'a> AgentRunner<'a> {
 
         self.memory.add(Role::User, &task);
 
+        let tool_descriptors = self.tools.descriptions(self.tool_format);
+
         for step in 0..self.config.max_steps {
-            let messages: Vec<Message> = self
+            // Build structured conversation turns from memory for the API call.
+            let turns: Vec<ConversationTurn> = self
                 .memory
                 .entries()
                 .iter()
-                .map(|e| Message {
-                    // Role::Tool has no direct equivalent in the current Message format
-                    // (which lacks tool_call_id), so tool observations are surfaced to
-                    // the LLM as user messages to maintain API compatibility.
-                    role: match &e.role {
-                        Role::Tool => "user".to_string(),
-                        other => other.to_string(),
+                .map(|e| match &e.content {
+                    EntryContent::Text { text } => ConversationTurn::Text(Message {
+                        role: e.role.to_string(),
+                        content: text.clone(),
+                    }),
+                    EntryContent::ToolCall {
+                        id,
+                        name,
+                        arguments,
+                    } => ConversationTurn::AssistantToolCall {
+                        id: id.clone(),
+                        name: name.clone(),
+                        arguments: arguments.clone(),
                     },
-                    content: e.content.clone(),
+                    EntryContent::ToolResult {
+                        tool_call_id,
+                        content,
+                    } => ConversationTurn::ToolResult {
+                        tool_call_id: tool_call_id.clone(),
+                        content: content.clone(),
+                    },
                 })
                 .collect();
 
@@ -109,12 +127,12 @@ impl<'a> AgentRunner<'a> {
                 &self.config.id,
                 step,
                 EventKind::Prompt,
-                serde_json::json!({ "message_count": messages.len() }),
+                serde_json::json!({ "turn_count": turns.len() }),
             )?;
 
             let response = self
                 .llm
-                .complete(Some(&self.config.system_prompt), &messages)
+                .complete(Some(&self.config.system_prompt), &turns, &tool_descriptors)
                 .await?;
 
             if response.content.is_none() && response.tool_call.is_none() {
@@ -148,6 +166,17 @@ impl<'a> AgentRunner<'a> {
                     serde_json::json!({ "tool": tc.name, "args": tc.arguments }),
                 )?;
 
+                // Store the assistant's tool-call turn so the next request
+                // includes it — required by both Anthropic and OpenAI protocols.
+                self.memory.add_entry(
+                    Role::Assistant,
+                    EntryContent::ToolCall {
+                        id: tc.id.clone(),
+                        name: tc.name.clone(),
+                        arguments: tc.arguments.clone(),
+                    },
+                );
+
                 let observation = match self.tools.dispatch(&tc.name, tc.arguments.clone()).await {
                     Ok(result) => {
                         self.tracer
@@ -167,9 +196,12 @@ impl<'a> AgentRunner<'a> {
                     }
                 };
 
-                self.memory.add(
-                    Role::Tool,
-                    format!("Tool '{}' returned: {}", tc.name, observation),
+                self.memory.add_entry(
+                    Role::User,
+                    EntryContent::ToolResult {
+                        tool_call_id: tc.id.clone(),
+                        content: observation,
+                    },
                 );
             } else if response.is_final_answer() {
                 let answer = response.content.unwrap_or_default();

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -3,7 +3,7 @@ use tempfile::{NamedTempFile, TempDir};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::{LlmResponse, StubClient};
-use yaai_tools::{builtin::ReadTool, ToolRegistry};
+use yaai_tools::{builtin::ReadTool, ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::Tracer;
 
 fn cfg(max_steps: u32) -> AgentConfig {
@@ -33,7 +33,7 @@ async fn produces_final_answer_without_tools() {
     let tools = ToolRegistry::new();
     let (_tmp, tr) = tracer();
 
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("What is the answer?")
         .await
         .unwrap();
@@ -47,13 +47,13 @@ async fn produces_final_answer_without_tools() {
 async fn calls_tool_then_answers() {
     let (_f, path) = temp_file_path();
     let llm = StubClient::new(vec![
-        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::tool("call_1", "read", serde_json::json!({"file_path": path})),
         LlmResponse::text("The answer is 42."),
     ]);
     let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("Read the file")
         .await
         .unwrap();
@@ -67,14 +67,22 @@ async fn calls_tool_then_answers() {
 async fn respects_max_steps() {
     let (_f, path) = temp_file_path();
     let llm = StubClient::new(vec![
-        LlmResponse::tool("read", serde_json::json!({"file_path": path.clone()})),
-        LlmResponse::tool("read", serde_json::json!({"file_path": path.clone()})),
-        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::tool(
+            "call_1",
+            "read",
+            serde_json::json!({"file_path": path.clone()}),
+        ),
+        LlmResponse::tool(
+            "call_2",
+            "read",
+            serde_json::json!({"file_path": path.clone()}),
+        ),
+        LlmResponse::tool("call_3", "read", serde_json::json!({"file_path": path})),
     ]);
     let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
-    let err = AgentRunner::new(&cfg(3), &llm, &tools, &tr)
+    let err = AgentRunner::new(&cfg(3), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("loop forever")
         .await
         .unwrap_err();
@@ -87,7 +95,7 @@ async fn respects_max_steps() {
 async fn trace_has_correct_event_sequence() {
     let (_f, path) = temp_file_path();
     let llm = StubClient::new(vec![
-        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::tool("call_1", "read", serde_json::json!({"file_path": path})),
         LlmResponse::text("Result is done."),
     ]);
     let tools = ToolRegistry::new().register(ReadTool::new());
@@ -95,7 +103,7 @@ async fn trace_has_correct_event_sequence() {
 
     // Tracer is write-only (streams to ndjson); verify the run completed with
     // the expected step count as a proxy for correct event sequencing.
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("Read file")
         .await
         .unwrap();
@@ -110,19 +118,19 @@ async fn trace_has_correct_event_sequence() {
 async fn memory_accumulates_across_steps() {
     let (_f, path) = temp_file_path();
     let llm = StubClient::new(vec![
-        LlmResponse::tool("read", serde_json::json!({"file_path": path})),
+        LlmResponse::tool("call_1", "read", serde_json::json!({"file_path": path})),
         LlmResponse::text("Done."),
     ]);
     let tools = ToolRegistry::new().register(ReadTool::new());
     let (_tmp, tr) = tracer();
 
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("task")
         .await
         .unwrap();
 
-    // user task + tool result observation + final assistant = at least 3
-    assert!(result.memory.len() >= 3);
+    // user task + assistant tool_call + tool result + final assistant answer = 4
+    assert!(result.memory.len() >= 4);
     tr.close().await.unwrap();
 }
 
@@ -130,6 +138,7 @@ async fn memory_accumulates_across_steps() {
 async fn graceful_tool_error_continues_loop() {
     let llm = StubClient::new(vec![
         LlmResponse::tool(
+            "call_1",
             "read",
             serde_json::json!({"file_path": "/nonexistent/file.txt"}),
         ),
@@ -141,7 +150,7 @@ async fn graceful_tool_error_continues_loop() {
     // The tool error should be fed back as a ToolResult observation and the
     // loop should continue to the next LLM call rather than propagating the
     // error up to the caller.
-    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("read missing file")
         .await
         .unwrap();
@@ -161,7 +170,7 @@ async fn empty_llm_response_returns_error() {
     let tools = ToolRegistry::new();
     let (_tmp, tr) = tracer();
 
-    let err = AgentRunner::new(&cfg(5), &llm, &tools, &tr)
+    let err = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
         .run("task")
         .await
         .unwrap_err();

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -3,9 +3,10 @@
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::debug;
 
-use crate::{LlmClient, LlmResponse, Message};
+use crate::{ConversationTurn, LlmClient, LlmResponse, Message};
 
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -54,7 +55,34 @@ struct MessagesRequest<'a> {
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     system: Option<&'a str>,
-    messages: &'a [Message],
+    messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    tools: &'a [Value],
+}
+
+/// A single message in the Anthropic wire format. Content is always a list of
+/// blocks — even for plain text — to support multi-part assistant/tool turns.
+#[derive(Serialize)]
+struct AnthropicMessage {
+    role: &'static str,
+    content: Vec<AnthropicBlock>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AnthropicBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
 }
 
 #[derive(Deserialize)]
@@ -69,8 +97,9 @@ enum ContentBlock {
         text: String,
     },
     ToolUse {
+        id: String,
         name: String,
-        input: serde_json::Value,
+        input: Value,
     },
     #[serde(other)]
     Unknown,
@@ -78,17 +107,62 @@ enum ContentBlock {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+fn turn_to_anthropic(turn: &ConversationTurn) -> AnthropicMessage {
+    match turn {
+        ConversationTurn::Text(Message { role, content }) => AnthropicMessage {
+            role: if role == "assistant" {
+                "assistant"
+            } else {
+                "user"
+            },
+            content: vec![AnthropicBlock::Text {
+                text: content.clone(),
+            }],
+        },
+        ConversationTurn::AssistantToolCall {
+            id,
+            name,
+            arguments,
+        } => AnthropicMessage {
+            role: "assistant",
+            content: vec![AnthropicBlock::ToolUse {
+                id: id.clone(),
+                name: name.clone(),
+                input: arguments.clone(),
+            }],
+        },
+        ConversationTurn::ToolResult {
+            tool_call_id,
+            content,
+        } => AnthropicMessage {
+            role: "user",
+            content: vec![AnthropicBlock::ToolResult {
+                tool_use_id: tool_call_id.clone(),
+                content: content.clone(),
+            }],
+        },
+    }
+}
+
 // grcov-excl-start: real HTTP transport requires integration tests or an injected client seam
 #[async_trait]
 impl LlmClient for AnthropicClient {
-    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
-        debug!(model = %self.model, messages = messages.len(), "calling Anthropic");
+    async fn complete(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+    ) -> Result<LlmResponse> {
+        debug!(model = %self.model, turns = turns.len(), "calling Anthropic");
+
+        let messages: Vec<AnthropicMessage> = turns.iter().map(turn_to_anthropic).collect();
 
         let body = MessagesRequest {
             model: &self.model,
             max_tokens: DEFAULT_MAX_TOKENS,
             system,
             messages,
+            tools,
         };
 
         let response = self
@@ -114,8 +188,8 @@ impl LlmClient for AnthropicClient {
 
         // Prefer tool_use blocks first (same priority as OpenAI implementation).
         for block in &resp.content {
-            if let ContentBlock::ToolUse { name, input } = block {
-                return Ok(LlmResponse::tool(name.clone(), input.clone()));
+            if let ContentBlock::ToolUse { id, name, input } = block {
+                return Ok(LlmResponse::tool(id.clone(), name.clone(), input.clone()));
             }
         }
 
@@ -130,6 +204,103 @@ impl LlmClient for AnthropicClient {
             content: None,
             tool_call: None,
         })
+    }
+}
+// grcov-excl-stop
+
+// grcov-excl-start: exclude inline unit tests from production coverage
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_turn(role: &str, content: &str) -> ConversationTurn {
+        ConversationTurn::Text(Message {
+            role: role.to_string(),
+            content: content.to_string(),
+        })
+    }
+
+    #[test]
+    fn user_text_turn_maps_to_user_role_with_text_block() {
+        let msg = turn_to_anthropic(&text_turn("user", "hello"));
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.len(), 1);
+        let json = serde_json::to_value(&msg.content[0]).unwrap();
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["text"], "hello");
+    }
+
+    #[test]
+    fn assistant_text_turn_maps_to_assistant_role() {
+        let msg = turn_to_anthropic(&text_turn("assistant", "done"));
+        assert_eq!(msg.role, "assistant");
+        let json = serde_json::to_value(&msg.content[0]).unwrap();
+        assert_eq!(json["type"], "text");
+        assert_eq!(json["text"], "done");
+    }
+
+    #[test]
+    fn system_text_turn_falls_through_to_user_role() {
+        // Any non-"assistant" role maps to "user" at the wire level.
+        let msg = turn_to_anthropic(&text_turn("system", "sys prompt"));
+        assert_eq!(msg.role, "user");
+    }
+
+    #[test]
+    fn assistant_tool_call_maps_to_tool_use_block() {
+        let turn = ConversationTurn::AssistantToolCall {
+            id: "toolu_01".to_string(),
+            name: "read".to_string(),
+            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+        };
+        let msg = turn_to_anthropic(&turn);
+        assert_eq!(msg.role, "assistant");
+        let json = serde_json::to_value(&msg.content[0]).unwrap();
+        assert_eq!(json["type"], "tool_use");
+        assert_eq!(json["id"], "toolu_01");
+        assert_eq!(json["name"], "read");
+        assert_eq!(json["input"]["file_path"], "/tmp/a.txt");
+    }
+
+    #[test]
+    fn tool_result_maps_to_user_role_with_tool_result_block() {
+        let turn = ConversationTurn::ToolResult {
+            tool_call_id: "toolu_01".to_string(),
+            content: "file contents here".to_string(),
+        };
+        let msg = turn_to_anthropic(&turn);
+        assert_eq!(msg.role, "user");
+        let json = serde_json::to_value(&msg.content[0]).unwrap();
+        assert_eq!(json["type"], "tool_result");
+        assert_eq!(json["tool_use_id"], "toolu_01");
+        assert_eq!(json["content"], "file contents here");
+    }
+
+    #[test]
+    fn empty_tools_omitted_from_request_json() {
+        let req = MessagesRequest {
+            model: "claude-test",
+            max_tokens: 100,
+            system: None,
+            messages: vec![],
+            tools: &[],
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("tools").is_none(), "empty tools must be omitted");
+    }
+
+    #[test]
+    fn non_empty_tools_included_in_request_json() {
+        let tools = vec![serde_json::json!({"type": "function", "name": "read"})];
+        let req = MessagesRequest {
+            model: "claude-test",
+            max_tokens: 100,
+            system: None,
+            messages: vec![],
+            tools: &tools,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("tools").is_some());
     }
 }
 // grcov-excl-stop

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -12,6 +12,7 @@ pub mod stub;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Build a [`reqwest::Client`] with sensible defaults: 10 s connect timeout,
 /// 120 s overall request timeout.
@@ -27,7 +28,7 @@ pub use anthropic::AnthropicClient;
 pub use openai::OpenAiClient;
 pub use stub::StubClient;
 
-/// A message in the conversation history.
+/// A plain text message in the conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Message {
     pub role: String,
@@ -57,11 +58,32 @@ impl Message {
     }
 }
 
+/// A structured conversation turn — text, a tool invocation, or a tool result.
+///
+/// Provider clients receive `&[ConversationTurn]` and are responsible for
+/// serialising each variant into their own wire format.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum ConversationTurn {
+    Text(Message),
+    AssistantToolCall {
+        /// Provider-issued call ID used to correlate result messages.
+        id: String,
+        name: String,
+        arguments: Value,
+    },
+    ToolResult {
+        tool_call_id: String,
+        content: String,
+    },
+}
+
 /// A tool call emitted by the LLM.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolCall {
+    /// Provider-issued call ID (e.g. `toolu_01…` for Anthropic, `call_01…` for OpenAI).
+    pub id: String,
     pub name: String,
-    pub arguments: serde_json::Value,
+    pub arguments: Value,
 }
 
 /// The LLM's response to a completion request.
@@ -81,10 +103,11 @@ impl LlmResponse {
         }
     }
 
-    pub fn tool(name: impl Into<String>, arguments: serde_json::Value) -> Self {
+    pub fn tool(id: impl Into<String>, name: impl Into<String>, arguments: Value) -> Self {
         Self {
             content: None,
             tool_call: Some(ToolCall {
+                id: id.into(),
                 name: name.into(),
                 arguments,
             }),
@@ -97,19 +120,30 @@ impl LlmResponse {
     }
 }
 
-/// Core LLM abstraction — send messages, receive a response.
+/// Core LLM abstraction — send a structured conversation, receive a response.
 ///
-/// `system` is passed separately so providers that require a dedicated
-/// system field (e.g. Anthropic) can handle it natively, while others
-/// (e.g. OpenAI) can prepend it to the messages array.
+/// `system` is passed separately so providers that require a dedicated system
+/// field (e.g. Anthropic) can handle it natively.
+/// `tools` carries pre-formatted tool descriptors (Anthropic or OpenAI shape)
+/// to include in the request.
 #[async_trait]
 pub trait LlmClient: Send + Sync {
-    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse>;
+    async fn complete(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+    ) -> Result<LlmResponse>;
 }
 
 #[async_trait]
 impl LlmClient for Box<dyn LlmClient> {
-    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
-        (**self).complete(system, messages).await
+    async fn complete(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+    ) -> Result<LlmResponse> {
+        (**self).complete(system, turns, tools).await
     }
 }

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -3,9 +3,10 @@
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use tracing::debug;
 
-use crate::{LlmClient, LlmResponse, Message};
+use crate::{ConversationTurn, LlmClient, LlmResponse, Message};
 
 #[derive(Debug, Clone)]
 pub struct OpenAiClient {
@@ -39,7 +40,37 @@ impl OpenAiClient {
 #[derive(Serialize)]
 struct ChatRequest<'a> {
     model: &'a str,
-    messages: &'a [Message],
+    messages: Vec<OaiMessage>,
+    #[serde(skip_serializing_if = "<[_]>::is_empty")]
+    tools: &'a [Value],
+}
+
+/// A single message in the OpenAI wire format.
+#[derive(Serialize)]
+struct OaiMessage {
+    role: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    /// Present only on assistant messages that made tool calls.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_calls: Option<Vec<OaiOutboundToolCall>>,
+    /// Present only on tool-result messages.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_call_id: Option<String>,
+}
+
+#[derive(Serialize)]
+struct OaiOutboundToolCall {
+    id: String,
+    #[serde(rename = "type")]
+    kind: &'static str,
+    function: OaiOutboundFunction,
+}
+
+#[derive(Serialize)]
+struct OaiOutboundFunction {
+    name: String,
+    arguments: String,
 }
 
 #[derive(Deserialize)]
@@ -55,16 +86,17 @@ struct Choice {
 #[derive(Deserialize)]
 struct ResponseMessage {
     content: Option<String>,
-    tool_calls: Option<Vec<OaiToolCall>>,
+    tool_calls: Option<Vec<OaiInboundToolCall>>,
 }
 
 #[derive(Deserialize)]
-struct OaiToolCall {
-    function: OaiFunction,
+struct OaiInboundToolCall {
+    id: String,
+    function: OaiInboundFunction,
 }
 
 #[derive(Deserialize)]
-struct OaiFunction {
+struct OaiInboundFunction {
     name: String,
     /// JSON-encoded string of the arguments object.
     arguments: String,
@@ -72,26 +104,76 @@ struct OaiFunction {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+fn turn_to_oai(turn: &ConversationTurn) -> OaiMessage {
+    match turn {
+        ConversationTurn::Text(Message { role, content }) => OaiMessage {
+            role: if role == "assistant" {
+                "assistant"
+            } else {
+                "user"
+            },
+            content: Some(content.clone()),
+            tool_calls: None,
+            tool_call_id: None,
+        },
+        ConversationTurn::AssistantToolCall {
+            id,
+            name,
+            arguments,
+        } => OaiMessage {
+            role: "assistant",
+            content: None,
+            tool_calls: Some(vec![OaiOutboundToolCall {
+                id: id.clone(),
+                kind: "function",
+                function: OaiOutboundFunction {
+                    name: name.clone(),
+                    arguments: arguments.to_string(),
+                },
+            }]),
+            tool_call_id: None,
+        },
+        ConversationTurn::ToolResult {
+            tool_call_id,
+            content,
+        } => OaiMessage {
+            role: "tool",
+            content: Some(content.clone()),
+            tool_calls: None,
+            tool_call_id: Some(tool_call_id.clone()),
+        },
+    }
+}
+
 // grcov-excl-start: real HTTP transport requires integration tests or an injected client seam
 #[async_trait]
 impl LlmClient for OpenAiClient {
-    async fn complete(&self, system: Option<&str>, messages: &[Message]) -> Result<LlmResponse> {
-        debug!(model = %self.model, messages = messages.len(), "calling OpenAI");
+    async fn complete(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+    ) -> Result<LlmResponse> {
+        debug!(model = %self.model, turns = turns.len(), "calling OpenAI");
 
         // OpenAI expects the system prompt as the first entry in the messages array.
-        let prepended: Vec<Message>;
-        let messages = if let Some(sys) = system {
-            prepended = std::iter::once(Message::system(sys))
-                .chain(messages.iter().cloned())
-                .collect();
-            prepended.as_slice()
-        } else {
-            messages
-        };
+        let mut messages: Vec<OaiMessage> = turns.iter().map(turn_to_oai).collect();
+        if let Some(sys) = system {
+            messages.insert(
+                0,
+                OaiMessage {
+                    role: "system",
+                    content: Some(sys.to_string()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                },
+            );
+        }
 
         let body = ChatRequest {
             model: &self.model,
             messages,
+            tools,
         };
 
         let response = self
@@ -120,9 +202,9 @@ impl LlmClient for OpenAiClient {
 
         if let Some(tool_calls) = msg.tool_calls {
             if let Some(tc) = tool_calls.into_iter().next() {
-                let args: serde_json::Value = serde_json::from_str(&tc.function.arguments)
+                let args: Value = serde_json::from_str(&tc.function.arguments)
                     .context("parsing tool call arguments")?;
-                return Ok(LlmResponse::tool(tc.function.name, args));
+                return Ok(LlmResponse::tool(tc.id, tc.function.name, args));
             }
         }
 
@@ -130,6 +212,113 @@ impl LlmClient for OpenAiClient {
             content: msg.content,
             tool_call: None,
         })
+    }
+}
+// grcov-excl-stop
+
+// grcov-excl-start: exclude inline unit tests from production coverage
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn text_turn(role: &str, content: &str) -> ConversationTurn {
+        ConversationTurn::Text(Message {
+            role: role.to_string(),
+            content: content.to_string(),
+        })
+    }
+
+    #[test]
+    fn user_text_turn_maps_to_user_role() {
+        let msg = turn_to_oai(&text_turn("user", "hello"));
+        assert_eq!(msg.role, "user");
+        assert_eq!(msg.content.as_deref(), Some("hello"));
+        assert!(msg.tool_calls.is_none());
+        assert!(msg.tool_call_id.is_none());
+    }
+
+    #[test]
+    fn assistant_text_turn_maps_to_assistant_role() {
+        let msg = turn_to_oai(&text_turn("assistant", "done"));
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content.as_deref(), Some("done"));
+    }
+
+    #[test]
+    fn system_text_turn_falls_through_to_user_role() {
+        let msg = turn_to_oai(&text_turn("system", "sys"));
+        assert_eq!(msg.role, "user");
+    }
+
+    #[test]
+    fn assistant_tool_call_serializes_to_tool_calls_array() {
+        let turn = ConversationTurn::AssistantToolCall {
+            id: "call_01".to_string(),
+            name: "read".to_string(),
+            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+        };
+        let msg = turn_to_oai(&turn);
+        assert_eq!(msg.role, "assistant");
+        assert!(msg.content.is_none());
+        assert!(msg.tool_call_id.is_none());
+
+        let calls = msg.tool_calls.unwrap();
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_01");
+        assert_eq!(calls[0].kind, "function");
+        assert_eq!(calls[0].function.name, "read");
+        // arguments must be a JSON string (OpenAI wire format)
+        let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
+        assert_eq!(args["file_path"], "/tmp/a.txt");
+    }
+
+    #[test]
+    fn tool_result_maps_to_tool_role_with_tool_call_id() {
+        let turn = ConversationTurn::ToolResult {
+            tool_call_id: "call_01".to_string(),
+            content: "file contents".to_string(),
+        };
+        let msg = turn_to_oai(&turn);
+        assert_eq!(msg.role, "tool");
+        assert_eq!(msg.content.as_deref(), Some("file contents"));
+        assert_eq!(msg.tool_call_id.as_deref(), Some("call_01"));
+        assert!(msg.tool_calls.is_none());
+    }
+
+    #[test]
+    fn empty_tools_omitted_from_request_json() {
+        let req = ChatRequest {
+            model: "gpt-test",
+            messages: vec![],
+            tools: &[],
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("tools").is_none(), "empty tools must be omitted");
+    }
+
+    #[test]
+    fn non_empty_tools_included_in_request_json() {
+        let tools = vec![serde_json::json!({"type": "function", "name": "read"})];
+        let req = ChatRequest {
+            model: "gpt-test",
+            messages: vec![],
+            tools: &tools,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("tools").is_some());
+    }
+
+    #[test]
+    fn optional_fields_omitted_when_none() {
+        let msg = OaiMessage {
+            role: "user",
+            content: Some("hi".to_string()),
+            tool_calls: None,
+            tool_call_id: None,
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert!(json.get("tool_calls").is_none());
+        assert!(json.get("tool_call_id").is_none());
     }
 }
 // grcov-excl-stop

--- a/crates/llm/src/stub.rs
+++ b/crates/llm/src/stub.rs
@@ -1,15 +1,10 @@
-//! A scripted LLM stub for deterministic testing.
-//!
-//! [`StubClient`] returns pre-scripted [`LlmResponse`]s in order.
-//! It returns an error if the script is exhausted, which signals that the
-//! agent ran more steps than the test anticipated.
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{anyhow, Result};
 use async_trait::async_trait;
+use serde_json::Value;
 
-use crate::{LlmClient, LlmResponse, Message};
+use crate::{ConversationTurn, LlmClient, LlmResponse};
 
 pub struct StubClient {
     responses: Vec<LlmResponse>,
@@ -28,7 +23,12 @@ impl StubClient {
 
 #[async_trait]
 impl LlmClient for StubClient {
-    async fn complete(&self, _system: Option<&str>, _messages: &[Message]) -> Result<LlmResponse> {
+    async fn complete(
+        &self,
+        _system: Option<&str>,
+        _turns: &[ConversationTurn],
+        _tools: &[Value],
+    ) -> Result<LlmResponse> {
         let i = self.index.fetch_add(1, Ordering::SeqCst);
         self.responses.get(i).cloned().ok_or_else(|| {
             anyhow!("StubClient script exhausted — agent ran more steps than expected")

--- a/crates/llm/tests/stub_tests.rs
+++ b/crates/llm/tests/stub_tests.rs
@@ -1,4 +1,4 @@
-use yaai_llm::{LlmClient, LlmResponse, Message, StubClient, ToolCall};
+use yaai_llm::{ConversationTurn, LlmClient, LlmResponse, Message, StubClient, ToolCall};
 
 #[tokio::test]
 async fn stub_returns_responses_in_order() {
@@ -7,11 +7,11 @@ async fn stub_returns_responses_in_order() {
         LlmResponse::text("second"),
         LlmResponse::text("third"),
     ]);
-    let msgs = vec![Message::user("test")];
+    let turns = vec![ConversationTurn::Text(Message::user("test"))];
 
-    let r1 = client.complete(None, &msgs).await.unwrap();
-    let r2 = client.complete(None, &msgs).await.unwrap();
-    let r3 = client.complete(None, &msgs).await.unwrap();
+    let r1 = client.complete(None, &turns, &[]).await.unwrap();
+    let r2 = client.complete(None, &turns, &[]).await.unwrap();
+    let r3 = client.complete(None, &turns, &[]).await.unwrap();
 
     assert_eq!(r1.content.as_deref(), Some("first"));
     assert_eq!(r2.content.as_deref(), Some("second"));
@@ -21,10 +21,10 @@ async fn stub_returns_responses_in_order() {
 #[tokio::test]
 async fn stub_errors_when_exhausted() {
     let client = StubClient::new(vec![LlmResponse::text("only one")]);
-    let msgs = vec![Message::user("test")];
+    let turns = vec![ConversationTurn::Text(Message::user("test"))];
 
-    client.complete(None, &msgs).await.unwrap();
-    let err = client.complete(None, &msgs).await;
+    client.complete(None, &turns, &[]).await.unwrap();
+    let err = client.complete(None, &turns, &[]).await;
     assert!(err.is_err());
     assert!(err.unwrap_err().to_string().contains("exhausted"));
 }
@@ -36,7 +36,11 @@ fn is_final_answer_when_no_tool_call() {
 
 #[test]
 fn not_final_when_tool_call_present() {
-    let r = LlmResponse::tool("calculator", serde_json::json!({"expression": "1+1"}));
+    let r = LlmResponse::tool(
+        "call_1",
+        "calculator",
+        serde_json::json!({"expression": "1+1"}),
+    );
     assert!(!r.is_final_answer());
 }
 
@@ -71,9 +75,10 @@ fn llm_response_text_has_content_no_tool_call() {
 #[test]
 fn llm_response_tool_has_tool_call_no_content() {
     let args = serde_json::json!({"x": 1});
-    let r = LlmResponse::tool("my_tool", args.clone());
+    let r = LlmResponse::tool("call_1", "my_tool", args.clone());
     assert!(r.content.is_none());
     let tc = r.tool_call.unwrap();
+    assert_eq!(tc.id, "call_1");
     assert_eq!(tc.name, "my_tool");
     assert_eq!(tc.arguments, args);
 }
@@ -90,10 +95,12 @@ fn llm_response_neither_is_not_final() {
 #[test]
 fn tool_call_equality() {
     let a = ToolCall {
+        id: "call_1".to_string(),
         name: "calc".to_string(),
         arguments: serde_json::json!({"expression": "1+1"}),
     };
     let b = ToolCall {
+        id: "call_1".to_string(),
         name: "calc".to_string(),
         arguments: serde_json::json!({"expression": "1+1"}),
     };
@@ -105,7 +112,7 @@ async fn box_dyn_client_delegates() {
     let inner = StubClient::new(vec![LlmResponse::text("delegated")]);
     let boxed: Box<dyn LlmClient> = Box::new(inner);
     let result = boxed
-        .complete(None, &[Message::user("test")])
+        .complete(None, &[ConversationTurn::Text(Message::user("test"))], &[])
         .await
         .unwrap();
     assert_eq!(result.content.as_deref(), Some("delegated"));
@@ -131,21 +138,24 @@ fn llm_response_text_serde_round_trip() {
 
 #[test]
 fn llm_response_tool_serde_round_trip() {
-    let r = LlmResponse::tool("calc", serde_json::json!({"expr": "1+1"}));
+    let r = LlmResponse::tool("call_1", "calc", serde_json::json!({"expr": "1+1"}));
     let json = serde_json::to_string(&r).unwrap();
     let r2: LlmResponse = serde_json::from_str(&json).unwrap();
     let tc = r2.tool_call.unwrap();
     assert_eq!(tc.name, "calc");
+    assert_eq!(tc.id, "call_1");
 }
 
 #[test]
 fn tool_call_serde_round_trip() {
     let tc = ToolCall {
+        id: "call_1".to_string(),
         name: "my_tool".to_string(),
         arguments: serde_json::json!({"x": 42}),
     };
     let json = serde_json::to_string(&tc).unwrap();
     let tc2: ToolCall = serde_json::from_str(&json).unwrap();
+    assert_eq!(tc2.id, "call_1");
     assert_eq!(tc2.name, "my_tool");
     assert_eq!(tc2.arguments["x"], 42);
 }

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -5,6 +5,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// The role of a message in the session history.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -14,6 +15,25 @@ pub enum Role {
     User,
     Assistant,
     Tool,
+}
+
+/// The content of a memory entry — either plain text, a tool invocation made
+/// by the assistant, or the result returned to the assistant after execution.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EntryContent {
+    Text {
+        text: String,
+    },
+    ToolCall {
+        id: String,
+        name: String,
+        arguments: Value,
+    },
+    ToolResult {
+        tool_call_id: String,
+        content: String,
+    },
 }
 
 impl std::fmt::Display for Role {
@@ -31,15 +51,17 @@ impl std::fmt::Display for Role {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryEntry {
     pub role: Role,
-    pub content: String,
+    pub content: EntryContent,
     pub timestamp: DateTime<Utc>,
 }
 
 impl MemoryEntry {
-    pub fn new(role: Role, content: impl Into<String>) -> Self {
+    pub fn text(role: Role, content: impl Into<String>) -> Self {
         Self {
             role,
-            content: content.into(),
+            content: EntryContent::Text {
+                text: content.into(),
+            },
             timestamp: Utc::now(),
         }
     }
@@ -63,9 +85,18 @@ impl SessionMemory {
         self.entries.push(entry);
     }
 
-    /// Convenience: push a message by role + content.
+    /// Convenience: push a plain-text message.
     pub fn add(&mut self, role: Role, content: impl Into<String>) {
-        self.push(MemoryEntry::new(role, content));
+        self.push(MemoryEntry::text(role, content));
+    }
+
+    /// Convenience: push a structured entry.
+    pub fn add_entry(&mut self, role: Role, content: EntryContent) {
+        self.push(MemoryEntry {
+            role,
+            content,
+            timestamp: chrono::Utc::now(),
+        });
     }
 
     /// All entries in insertion order.
@@ -95,25 +126,60 @@ mod tests {
         mem.add(Role::Assistant, "hi there");
 
         assert_eq!(mem.len(), 2);
-        assert_eq!(mem.entries()[0].content, "hello");
+        assert!(
+            matches!(&mem.entries()[0].content, EntryContent::Text { text } if text == "hello")
+        );
         assert_eq!(mem.entries()[1].role, Role::Assistant);
     }
 
     #[test]
     fn push_directly_with_memory_entry() {
         let mut mem = SessionMemory::new();
-        let entry = MemoryEntry::new(Role::Assistant, "direct push");
+        let entry = MemoryEntry::text(Role::Assistant, "direct push");
         mem.push(entry);
 
         assert_eq!(mem.len(), 1);
         assert_eq!(mem.entries()[0].role, Role::Assistant);
-        assert_eq!(mem.entries()[0].content, "direct push");
+        assert!(
+            matches!(&mem.entries()[0].content, EntryContent::Text { text } if text == "direct push")
+        );
+    }
+
+    #[test]
+    fn add_entry_stores_structured_content() {
+        let mut mem = SessionMemory::new();
+        mem.add_entry(
+            Role::Assistant,
+            EntryContent::ToolCall {
+                id: "call_1".into(),
+                name: "read".into(),
+                arguments: serde_json::json!({ "file_path": "/LICENSE" }),
+            },
+        );
+        mem.add_entry(
+            Role::User,
+            EntryContent::ToolResult {
+                tool_call_id: "call_1".into(),
+                content: "MIT License".into(),
+            },
+        );
+
+        assert_eq!(mem.len(), 2);
+        assert!(matches!(
+            &mem.entries()[0].content,
+            EntryContent::ToolCall { id, .. } if id == "call_1"
+        ));
+        assert!(matches!(
+            &mem.entries()[1].content,
+            EntryContent::ToolResult { tool_call_id, .. } if tool_call_id == "call_1"
+        ));
     }
 
     #[test]
     fn is_empty_on_new() {
         assert!(SessionMemory::new().is_empty());
     }
+
     #[test]
     fn role_serde_round_trip() {
         for (role, expected) in [
@@ -128,11 +194,11 @@ mod tests {
             assert_eq!(r2, role);
         }
 
-        let entry = MemoryEntry::new(Role::User, "hello");
+        let entry = MemoryEntry::text(Role::User, "hello");
         let json = serde_json::to_string(&entry).unwrap();
         let e2: MemoryEntry = serde_json::from_str(&json).unwrap();
-        assert_eq!(e2.content, "hello");
         assert_eq!(e2.role, Role::User);
+        assert!(matches!(e2.content, EntryContent::Text { text } if text == "hello"));
     }
 }
 // grcov-excl-stop

--- a/crates/orchestrator/src/single.rs
+++ b/crates/orchestrator/src/single.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentResult, AgentRunner};
 use yaai_llm::LlmClient;
-use yaai_tools::ToolRegistry;
+use yaai_tools::{ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::Tracer;
 
 /// Run a single agent on a task, flush the trace, and return the result.
@@ -12,10 +12,11 @@ pub async fn run_single(
     llm: &dyn LlmClient,
     tools: &ToolRegistry,
     traces_dir: &str,
+    tool_format: ToolSchemaFormat,
 ) -> Result<AgentResult> {
     let tracer = Tracer::new(Uuid::new_v4(), traces_dir)?;
 
-    let result = AgentRunner::new(config, llm, tools, &tracer)
+    let result = AgentRunner::new(config, llm, tools, &tracer, tool_format)
         .run(task)
         .await;
 

--- a/crates/orchestrator/tests/single.rs
+++ b/crates/orchestrator/tests/single.rs
@@ -1,7 +1,7 @@
 use yaai_agent_loop::AgentConfig;
 use yaai_llm::{LlmResponse, StubClient};
 use yaai_orchestrator::run_single;
-use yaai_tools::ToolRegistry;
+use yaai_tools::{ToolRegistry, ToolSchemaFormat};
 
 fn cfg(id: &str) -> AgentConfig {
     AgentConfig {
@@ -23,6 +23,7 @@ async fn single_agent_completes() {
         &llm,
         &tools,
         dir.path().to_str().unwrap(),
+        ToolSchemaFormat::OpenAi,
     )
     .await
     .unwrap();
@@ -43,6 +44,7 @@ async fn single_agent_closes_tracer_on_error() {
         &llm,
         &tools,
         dir.path().to_str().unwrap(),
+        ToolSchemaFormat::OpenAi,
     )
     .await
     .unwrap_err();

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 serde = { workspace = true }
 serde_json = { workspace = true }
+schemars = { workspace = true }
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 tracing = { workspace = true }

--- a/crates/tools/src/builtin/read.rs
+++ b/crates/tools/src/builtin/read.rs
@@ -79,7 +79,15 @@ impl Tool for ReadTool {
     }
 
     fn input_schema(&self) -> Value {
-        serde_json::to_value(schema_for!(ReadInput)).expect("ReadInput schema is always valid")
+        let mut schema =
+            serde_json::to_value(schema_for!(ReadInput)).expect("ReadInput schema is always valid");
+        // Drop draft-07 metadata: some OpenAI strict-mode validators reject `$schema`
+        // in `parameters`, and `title` leaks the Rust type name into model-visible errors.
+        if let Some(obj) = schema.as_object_mut() {
+            obj.remove("$schema");
+            obj.remove("title");
+        }
+        schema
     }
 
     async fn execute(&self, input: Value) -> Result<Value, ToolError> {
@@ -515,6 +523,18 @@ mod tests {
 
         let payload = content.trim_start_matches("1: ");
         assert_eq!(payload.len(), big.len(), "line 1 must be returned in full");
+    }
+
+    #[test]
+    fn input_schema_strips_draft_metadata() {
+        let schema = ReadTool::new().input_schema();
+        let obj = schema.as_object().expect("schema must be an object");
+        assert!(!obj.contains_key("$schema"), "$schema must be stripped");
+        assert!(!obj.contains_key("title"), "title must be stripped");
+        assert!(
+            obj.contains_key("properties"),
+            "properties must be preserved"
+        );
     }
 
     #[tokio::test]

--- a/crates/tools/src/builtin/read.rs
+++ b/crates/tools/src/builtin/read.rs
@@ -1,12 +1,25 @@
 use crate::{Tool, ToolError};
 use async_trait::async_trait;
-use serde::Serialize;
+use schemars::{schema_for, JsonSchema};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader};
 
 const DEFAULT_LIMIT: usize = 2000;
 const MAX_BYTES: usize = 512 * 1024; // 512 KB
 const BINARY_SAMPLE_BYTES: usize = 8192;
+
+/// Typed input for the `read` tool. Used to generate the JSON Schema and
+/// to deserialise the LLM's tool call arguments — keeping both in sync.
+#[derive(Debug, Deserialize, JsonSchema)]
+struct ReadInput {
+    /// Absolute path to the file to read.
+    file_path: String,
+    /// 1-indexed line number to start reading from. Defaults to 1. Must be >= 1.
+    offset: Option<u64>,
+    /// Maximum number of lines to return. Defaults to 2000. Must be >= 1.
+    limit: Option<u64>,
+}
 
 /// The `lines` range returned inside a [`ReadResult`].
 #[derive(Debug, Serialize)]
@@ -66,53 +79,31 @@ impl Tool for ReadTool {
     }
 
     fn input_schema(&self) -> Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "file_path": {
-                    "type": "string",
-                    "description": "Absolute path to the file to read."
-                },
-                "offset": {
-                    "type": "integer",
-                    "description": "1-indexed line number to start reading from. Defaults to 1.",
-                    "minimum": 1
-                },
-                "limit": {
-                    "type": "integer",
-                    "description": "Maximum number of lines to return. Defaults to 2000.",
-                    "minimum": 1
-                }
-            },
-            "required": ["file_path"]
-        })
+        serde_json::to_value(schema_for!(ReadInput)).expect("ReadInput schema is always valid")
     }
 
     async fn execute(&self, input: Value) -> Result<Value, ToolError> {
-        let file_path = input
-            .get("file_path")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::InvalidInput {
+        let params: ReadInput =
+            serde_json::from_value(input).map_err(|e| ToolError::InvalidInput {
                 name: self.name().to_string(),
-                reason: "missing or invalid 'file_path' field".to_string(),
+                reason: e.to_string(),
             })?;
 
-        let offset = input
-            .get("offset")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize)
-            .unwrap_or(1);
-
-        let limit = input
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .map(|v| v as usize)
-            .unwrap_or(DEFAULT_LIMIT);
+        let file_path = &params.file_path;
+        let offset = params.offset.unwrap_or(1) as usize;
+        let limit = params.limit.unwrap_or(DEFAULT_LIMIT as u64) as usize;
 
         if offset == 0 {
             return Err(ToolError::InvalidInput {
                 name: self.name().to_string(),
                 reason: "offset must be >= 1".to_string(),
+            });
+        }
+
+        if limit == 0 {
+            return Err(ToolError::InvalidInput {
+                name: self.name().to_string(),
+                reason: "limit must be >= 1".to_string(),
             });
         }
 
@@ -387,6 +378,19 @@ mod tests {
             }
             _ => panic!("expected ExecutionFailed for binary file"),
         }
+    }
+
+    #[tokio::test]
+    async fn errors_on_zero_limit() {
+        let mut f = NamedTempFile::new().unwrap();
+        writeln!(f, "line").unwrap();
+
+        let tool = ReadTool::new();
+        let result = tool
+            .execute(make_input(f.path().to_str().unwrap(), None, Some(0)))
+            .await;
+
+        assert!(matches!(result, Err(ToolError::InvalidInput { .. })));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The LLM was guessing tool parameter names (e.g. `path` instead of `file_path`) because tool schemas were never sent to the API. The model was working from system prompt text alone.

## Changes

### Typed tool schemas (`yaai-tools`)
Added `ReadInput` struct with `#[derive(Deserialize, JsonSchema)]` so the JSON Schema is generated from Rust field names — wrong param names now produce a clear `InvalidInput` error.

### Structured conversation history (`yaai-memory`)
Replaced plain `String` content with an `EntryContent` enum (`Text`, `ToolCall`, `ToolResult`), enabling the agent loop to construct proper multi-block message sequences.

### Native tool calling on the wire (`yaai-llm`)
- Added `tools` field to `MessagesRequest` (Anthropic) and `ChatRequest` (OpenAI) — schemas are now a top-level API field, not embedded in the system prompt.
- Added `ConversationTurn` enum and `id: String` to `ToolCall` so `tool_use`/`tool_result` pairs (Anthropic) and `tool_calls`/`role: tool` messages (OpenAI) are round-tripped correctly.
- Added unit tests for `turn_to_anthropic()` and `turn_to_oai()` covering all 3 `ConversationTurn` variants and `tools` field serialisation.

### Agent loop + CLI (`yaai-agent-loop`, `yaai-orchestrator`, `apps/cli`)
- `AgentRunner` now converts memory entries to `ConversationTurn` structs and passes tool descriptors to `complete()`.
- `ToolSchemaFormat` is derived from the provider at the CLI layer and threaded through to the registry's `descriptions()` call.