### PR TITLE
feat(llm): preserve reasoning alongside tool calls

### DIFF
--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -153,6 +153,11 @@ impl<'a> AgentRunner<'a> {
             }
 
             if let Some(ref text) = response.content {
+                // Emit a Decision trace for reasoning text regardless of whether a
+                // tool call follows — reasoning is always worth tracing. When a tool
+                // call is present the text is *not* added to memory here; instead it
+                // is stored inside the ToolCall entry below so both are replayed as a
+                // single assistant message (required by Anthropic and OpenAI).
                 self.tracer
                     .emit(&self.config.id, step, EventKind::Decision, text)?;
                 // Only store a standalone text entry when there is no tool call.

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -108,10 +108,12 @@ impl<'a> AgentRunner<'a> {
                         id,
                         name,
                         arguments,
+                        reasoning,
                     } => ConversationTurn::AssistantToolCall {
                         id: id.clone(),
                         name: name.clone(),
                         arguments: arguments.clone(),
+                        reasoning: reasoning.clone(),
                     },
                     EntryContent::ToolResult {
                         tool_call_id,
@@ -153,7 +155,11 @@ impl<'a> AgentRunner<'a> {
             if let Some(ref text) = response.content {
                 self.tracer
                     .emit(&self.config.id, step, EventKind::Decision, text)?;
-                self.memory.add(Role::Assistant, text);
+                // Only store a standalone text entry when there is no tool call.
+                // When a tool call is present, the reasoning is stored inside it.
+                if response.tool_call.is_none() {
+                    self.memory.add(Role::Assistant, text);
+                }
             }
 
             if let Some(tc) = &response.tool_call {
@@ -166,14 +172,15 @@ impl<'a> AgentRunner<'a> {
                     serde_json::json!({ "tool": tc.name, "args": tc.arguments }),
                 )?;
 
-                // Store the assistant's tool-call turn so the next request
-                // includes it — required by both Anthropic and OpenAI protocols.
+                // Store reasoning alongside the tool call so both are replayed as
+                // a single assistant message — required by Anthropic and OpenAI.
                 self.memory.add_entry(
                     Role::Assistant,
                     EntryContent::ToolCall {
                         id: tc.id.clone(),
                         name: tc.name.clone(),
                         arguments: tc.arguments.clone(),
+                        reasoning: response.content.clone(),
                     },
                 );
 

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -2,7 +2,8 @@ use std::io::Write;
 use tempfile::{NamedTempFile, TempDir};
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
-use yaai_llm::{LlmResponse, StubClient};
+use yaai_llm::{LlmResponse, StubClient, ToolCall};
+use yaai_memory::EntryContent;
 use yaai_tools::{builtin::ReadTool, ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::Tracer;
 
@@ -176,6 +177,62 @@ async fn empty_llm_response_returns_error() {
         .unwrap_err();
 
     assert!(err.to_string().contains("empty LLM response"));
+    tr.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn reasoning_with_tool_call_stored_as_single_memory_entry() {
+    let (_f, path) = temp_file_path();
+    // Simulate a response that has both reasoning text and a tool call.
+    let llm = StubClient::new(vec![
+        LlmResponse {
+            content: Some("I should read the file first.".to_string()),
+            tool_call: Some(ToolCall {
+                id: "call_1".to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({"file_path": path}),
+            }),
+        },
+        LlmResponse::text("Done."),
+    ]);
+    let tools = ToolRegistry::new().register(ReadTool::new());
+    let (_tmp, tr) = tracer();
+
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
+        .run("task")
+        .await
+        .unwrap();
+
+    // Exactly 4 entries: user task, assistant tool_call (with reasoning), tool result, final answer.
+    assert_eq!(result.memory.len(), 4);
+
+    // The tool-call entry must carry the reasoning.
+    let tool_call_entry = &result.memory.entries()[1];
+    assert!(
+        matches!(&tool_call_entry.content, EntryContent::ToolCall { reasoning, .. } if reasoning.as_deref() == Some("I should read the file first."))
+    );
+    tr.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn tool_call_without_reasoning_stores_no_reasoning() {
+    let (_f, path) = temp_file_path();
+    let llm = StubClient::new(vec![
+        LlmResponse::tool("call_1", "read", serde_json::json!({"file_path": path})),
+        LlmResponse::text("Done."),
+    ]);
+    let tools = ToolRegistry::new().register(ReadTool::new());
+    let (_tmp, tr) = tracer();
+
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
+        .run("task")
+        .await
+        .unwrap();
+
+    let tool_call_entry = &result.memory.entries()[1];
+    assert!(
+        matches!(&tool_call_entry.content, EntryContent::ToolCall { reasoning, .. } if reasoning.is_none())
+    );
     tr.close().await.unwrap();
 }
 

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -236,6 +236,27 @@ async fn tool_call_without_reasoning_stores_no_reasoning() {
     tr.close().await.unwrap();
 }
 
+#[tokio::test]
+async fn standalone_text_response_stored_as_text_memory_entry() {
+    // Regression: response.content = Some(...) with no tool call must create a
+    // standalone Text entry in memory. The `if response.tool_call.is_none()`
+    // guard in the agent loop is the only thing keeping this path working.
+    let llm = StubClient::new(vec![LlmResponse::text("Just a text answer.")]);
+    let tools = ToolRegistry::new();
+    let (_tmp, tr) = tracer();
+
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
+        .run("task")
+        .await
+        .unwrap();
+
+    // user task + assistant text answer = 2 entries
+    assert_eq!(result.memory.len(), 2);
+    let entry = &result.memory.entries()[1];
+    assert!(matches!(&entry.content, EntryContent::Text { text } if text == "Just a text answer."));
+    tr.close().await.unwrap();
+}
+
 #[test]
 fn agent_config_serde_round_trip() {
     use yaai_agent_loop::AgentResult;

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::{ConversationTurn, LlmClient, LlmResponse, Message};
+use crate::{ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -123,14 +123,22 @@ fn turn_to_anthropic(turn: &ConversationTurn) -> AnthropicMessage {
             id,
             name,
             arguments,
-        } => AnthropicMessage {
-            role: "assistant",
-            content: vec![AnthropicBlock::ToolUse {
+            reasoning,
+        } => {
+            let mut blocks = Vec::new();
+            if let Some(text) = reasoning {
+                blocks.push(AnthropicBlock::Text { text: text.clone() });
+            }
+            blocks.push(AnthropicBlock::ToolUse {
                 id: id.clone(),
                 name: name.clone(),
                 input: arguments.clone(),
-            }],
-        },
+            });
+            AnthropicMessage {
+                role: "assistant",
+                content: blocks,
+            }
+        }
         ConversationTurn::ToolResult {
             tool_call_id,
             content,
@@ -186,18 +194,31 @@ impl LlmClient for AnthropicClient {
             .await
             .context("parsing Anthropic response")?;
 
-        // Prefer tool_use blocks first (same priority as OpenAI implementation).
+        // Walk blocks in order: collect any text before a tool_use so reasoning
+        // is preserved alongside the call in a single LlmResponse.
+        let mut reasoning: Option<String> = None;
         for block in &resp.content {
-            if let ContentBlock::ToolUse { id, name, input } = block {
-                return Ok(LlmResponse::tool(id.clone(), name.clone(), input.clone()));
+            match block {
+                ContentBlock::Text { text } => {
+                    reasoning = Some(text.clone());
+                }
+                ContentBlock::ToolUse { id, name, input } => {
+                    return Ok(LlmResponse {
+                        content: reasoning,
+                        tool_call: Some(ToolCall {
+                            id: id.clone(),
+                            name: name.clone(),
+                            arguments: input.clone(),
+                        }),
+                    });
+                }
+                ContentBlock::Unknown => {}
             }
         }
 
-        // Fall back to the first text block.
-        for block in resp.content {
-            if let ContentBlock::Text { text } = block {
-                return Ok(LlmResponse::text(text));
-            }
+        // No tool call found — fall back to text content.
+        if let Some(text) = reasoning {
+            return Ok(LlmResponse::text(text));
         }
 
         Ok(LlmResponse {
@@ -252,6 +273,7 @@ mod tests {
             id: "toolu_01".to_string(),
             name: "read".to_string(),
             arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            reasoning: None,
         };
         let msg = turn_to_anthropic(&turn);
         assert_eq!(msg.role, "assistant");
@@ -301,6 +323,109 @@ mod tests {
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_some());
+    }
+
+    #[test]
+    fn tool_call_with_reasoning_emits_text_then_tool_use_blocks() {
+        let turn = ConversationTurn::AssistantToolCall {
+            id: "toolu_01".to_string(),
+            name: "read".to_string(),
+            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            reasoning: Some("I should read the file first.".to_string()),
+        };
+        let msg = turn_to_anthropic(&turn);
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content.len(), 2);
+        let first = serde_json::to_value(&msg.content[0]).unwrap();
+        assert_eq!(first["type"], "text");
+        assert_eq!(first["text"], "I should read the file first.");
+        let second = serde_json::to_value(&msg.content[1]).unwrap();
+        assert_eq!(second["type"], "tool_use");
+        assert_eq!(second["id"], "toolu_01");
+    }
+
+    #[test]
+    fn complete_text_then_tool_use_returns_reasoning_with_tool_call() {
+        // Simulate a multi-block response: text block followed by tool_use.
+        let resp = MessagesResponse {
+            content: vec![
+                ContentBlock::Text {
+                    text: "Let me check that file.".to_string(),
+                },
+                ContentBlock::ToolUse {
+                    id: "toolu_01".to_string(),
+                    name: "read".to_string(),
+                    input: serde_json::json!({"file_path": "/tmp/a.txt"}),
+                },
+            ],
+        };
+
+        // Exercise the parsing logic directly (mirrors what complete() does).
+        let mut reasoning: Option<String> = None;
+        let mut result: Option<LlmResponse> = None;
+        for block in &resp.content {
+            match block {
+                ContentBlock::Text { text } => {
+                    reasoning = Some(text.clone());
+                }
+                ContentBlock::ToolUse { id, name, input } => {
+                    result = Some(LlmResponse {
+                        content: reasoning.clone(),
+                        tool_call: Some(ToolCall {
+                            id: id.clone(),
+                            name: name.clone(),
+                            arguments: input.clone(),
+                        }),
+                    });
+                    break;
+                }
+                ContentBlock::Unknown => {}
+            }
+        }
+
+        let r = result.unwrap();
+        assert_eq!(r.content.as_deref(), Some("Let me check that file."));
+        let tc = r.tool_call.unwrap();
+        assert_eq!(tc.id, "toolu_01");
+        assert_eq!(tc.name, "read");
+    }
+
+    #[test]
+    fn complete_tool_use_only_returns_no_reasoning() {
+        // Tool-use block with no preceding text — reasoning should be None.
+        let resp = MessagesResponse {
+            content: vec![ContentBlock::ToolUse {
+                id: "toolu_02".to_string(),
+                name: "read".to_string(),
+                input: serde_json::json!({}),
+            }],
+        };
+
+        let mut reasoning: Option<String> = None;
+        let mut result: Option<LlmResponse> = None;
+        for block in &resp.content {
+            match block {
+                ContentBlock::Text { text } => {
+                    reasoning = Some(text.clone());
+                }
+                ContentBlock::ToolUse { id, name, input } => {
+                    result = Some(LlmResponse {
+                        content: reasoning.clone(),
+                        tool_call: Some(ToolCall {
+                            id: id.clone(),
+                            name: name.clone(),
+                            arguments: input.clone(),
+                        }),
+                    });
+                    break;
+                }
+                ContentBlock::Unknown => {}
+            }
+        }
+
+        let r = result.unwrap();
+        assert!(r.content.is_none());
+        assert!(r.tool_call.is_some());
     }
 }
 // grcov-excl-stop

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -152,6 +152,45 @@ fn turn_to_anthropic(turn: &ConversationTurn) -> AnthropicMessage {
     }
 }
 
+/// Parse a slice of [`ContentBlock`]s into an [`LlmResponse`].
+///
+/// Text blocks are concatenated (newline-separated) so that multiple `Text`
+/// blocks before a `ToolUse` are all preserved as reasoning. The first
+/// `ToolUse` block terminates the scan and the accumulated text is returned
+/// as `content` alongside the tool call.
+fn parse_blocks(blocks: &[ContentBlock]) -> LlmResponse {
+    let mut reasoning: Option<String> = None;
+    for block in blocks {
+        match block {
+            ContentBlock::Text { text } => match reasoning.as_mut() {
+                Some(r) => {
+                    r.push('\n');
+                    r.push_str(text);
+                }
+                None => reasoning = Some(text.clone()),
+            },
+            ContentBlock::ToolUse { id, name, input } => {
+                return LlmResponse {
+                    content: reasoning,
+                    tool_call: Some(ToolCall {
+                        id: id.clone(),
+                        name: name.clone(),
+                        arguments: input.clone(),
+                    }),
+                };
+            }
+            ContentBlock::Unknown => {}
+        }
+    }
+    if let Some(text) = reasoning {
+        return LlmResponse::text(text);
+    }
+    LlmResponse {
+        content: None,
+        tool_call: None,
+    }
+}
+
 // grcov-excl-start: real HTTP transport requires integration tests or an injected client seam
 #[async_trait]
 impl LlmClient for AnthropicClient {
@@ -194,37 +233,7 @@ impl LlmClient for AnthropicClient {
             .await
             .context("parsing Anthropic response")?;
 
-        // Walk blocks in order: collect any text before a tool_use so reasoning
-        // is preserved alongside the call in a single LlmResponse.
-        let mut reasoning: Option<String> = None;
-        for block in &resp.content {
-            match block {
-                ContentBlock::Text { text } => {
-                    reasoning = Some(text.clone());
-                }
-                ContentBlock::ToolUse { id, name, input } => {
-                    return Ok(LlmResponse {
-                        content: reasoning,
-                        tool_call: Some(ToolCall {
-                            id: id.clone(),
-                            name: name.clone(),
-                            arguments: input.clone(),
-                        }),
-                    });
-                }
-                ContentBlock::Unknown => {}
-            }
-        }
-
-        // No tool call found — fall back to text content.
-        if let Some(text) = reasoning {
-            return Ok(LlmResponse::text(text));
-        }
-
-        Ok(LlmResponse {
-            content: None,
-            tool_call: None,
-        })
+        Ok(parse_blocks(&resp.content))
     }
 }
 // grcov-excl-stop
@@ -346,44 +355,17 @@ mod tests {
 
     #[test]
     fn complete_text_then_tool_use_returns_reasoning_with_tool_call() {
-        // Simulate a multi-block response: text block followed by tool_use.
-        let resp = MessagesResponse {
-            content: vec![
-                ContentBlock::Text {
-                    text: "Let me check that file.".to_string(),
-                },
-                ContentBlock::ToolUse {
-                    id: "toolu_01".to_string(),
-                    name: "read".to_string(),
-                    input: serde_json::json!({"file_path": "/tmp/a.txt"}),
-                },
-            ],
-        };
-
-        // Exercise the parsing logic directly (mirrors what complete() does).
-        let mut reasoning: Option<String> = None;
-        let mut result: Option<LlmResponse> = None;
-        for block in &resp.content {
-            match block {
-                ContentBlock::Text { text } => {
-                    reasoning = Some(text.clone());
-                }
-                ContentBlock::ToolUse { id, name, input } => {
-                    result = Some(LlmResponse {
-                        content: reasoning.clone(),
-                        tool_call: Some(ToolCall {
-                            id: id.clone(),
-                            name: name.clone(),
-                            arguments: input.clone(),
-                        }),
-                    });
-                    break;
-                }
-                ContentBlock::Unknown => {}
-            }
-        }
-
-        let r = result.unwrap();
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "Let me check that file.".to_string(),
+            },
+            ContentBlock::ToolUse {
+                id: "toolu_01".to_string(),
+                name: "read".to_string(),
+                input: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            },
+        ];
+        let r = parse_blocks(&blocks);
         assert_eq!(r.content.as_deref(), Some("Let me check that file."));
         let tc = r.tool_call.unwrap();
         assert_eq!(tc.id, "toolu_01");
@@ -392,39 +374,36 @@ mod tests {
 
     #[test]
     fn complete_tool_use_only_returns_no_reasoning() {
-        // Tool-use block with no preceding text — reasoning should be None.
-        let resp = MessagesResponse {
-            content: vec![ContentBlock::ToolUse {
-                id: "toolu_02".to_string(),
+        let blocks = vec![ContentBlock::ToolUse {
+            id: "toolu_02".to_string(),
+            name: "read".to_string(),
+            input: serde_json::json!({}),
+        }];
+        let r = parse_blocks(&blocks);
+        assert!(r.content.is_none());
+        assert!(r.tool_call.is_some());
+    }
+
+    #[test]
+    fn multiple_text_blocks_are_concatenated_as_reasoning() {
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "First thought.".to_string(),
+            },
+            ContentBlock::Text {
+                text: "Second thought.".to_string(),
+            },
+            ContentBlock::ToolUse {
+                id: "toolu_03".to_string(),
                 name: "read".to_string(),
                 input: serde_json::json!({}),
-            }],
-        };
-
-        let mut reasoning: Option<String> = None;
-        let mut result: Option<LlmResponse> = None;
-        for block in &resp.content {
-            match block {
-                ContentBlock::Text { text } => {
-                    reasoning = Some(text.clone());
-                }
-                ContentBlock::ToolUse { id, name, input } => {
-                    result = Some(LlmResponse {
-                        content: reasoning.clone(),
-                        tool_call: Some(ToolCall {
-                            id: id.clone(),
-                            name: name.clone(),
-                            arguments: input.clone(),
-                        }),
-                    });
-                    break;
-                }
-                ContentBlock::Unknown => {}
-            }
-        }
-
-        let r = result.unwrap();
-        assert!(r.content.is_none());
+            },
+        ];
+        let r = parse_blocks(&blocks);
+        assert_eq!(
+            r.content.as_deref(),
+            Some("First thought.\nSecond thought.")
+        );
         assert!(r.tool_call.is_some());
     }
 }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -70,6 +70,8 @@ pub enum ConversationTurn {
         id: String,
         name: String,
         arguments: Value,
+        /// Text the model emitted before choosing this tool call (chain-of-thought).
+        reasoning: Option<String>,
     },
     ToolResult {
         tool_call_id: String,

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tracing::debug;
 
-use crate::{ConversationTurn, LlmClient, LlmResponse, Message};
+use crate::{ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
 #[derive(Debug, Clone)]
 pub struct OpenAiClient {
@@ -120,9 +120,10 @@ fn turn_to_oai(turn: &ConversationTurn) -> OaiMessage {
             id,
             name,
             arguments,
+            reasoning,
         } => OaiMessage {
             role: "assistant",
-            content: None,
+            content: reasoning.clone(),
             tool_calls: Some(vec![OaiOutboundToolCall {
                 id: id.clone(),
                 kind: "function",
@@ -204,7 +205,14 @@ impl LlmClient for OpenAiClient {
             if let Some(tc) = tool_calls.into_iter().next() {
                 let args: Value = serde_json::from_str(&tc.function.arguments)
                     .context("parsing tool call arguments")?;
-                return Ok(LlmResponse::tool(tc.id, tc.function.name, args));
+                return Ok(LlmResponse {
+                    content: msg.content, // preserve any reasoning alongside the tool call
+                    tool_call: Some(ToolCall {
+                        id: tc.id,
+                        name: tc.function.name,
+                        arguments: args,
+                    }),
+                });
             }
         }
 
@@ -256,6 +264,7 @@ mod tests {
             id: "call_01".to_string(),
             name: "read".to_string(),
             arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            reasoning: None,
         };
         let msg = turn_to_oai(&turn);
         assert_eq!(msg.role, "assistant");
@@ -319,6 +328,34 @@ mod tests {
         let json = serde_json::to_value(&msg).unwrap();
         assert!(json.get("tool_calls").is_none());
         assert!(json.get("tool_call_id").is_none());
+    }
+
+    #[test]
+    fn tool_call_with_reasoning_sets_content_alongside_tool_calls() {
+        let turn = ConversationTurn::AssistantToolCall {
+            id: "call_01".to_string(),
+            name: "read".to_string(),
+            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            reasoning: Some("I should read the file.".to_string()),
+        };
+        let msg = turn_to_oai(&turn);
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content.as_deref(), Some("I should read the file."));
+        assert!(msg.tool_calls.is_some());
+        assert_eq!(msg.tool_calls.unwrap()[0].id, "call_01");
+    }
+
+    #[test]
+    fn tool_call_without_reasoning_has_no_content() {
+        let turn = ConversationTurn::AssistantToolCall {
+            id: "call_02".to_string(),
+            name: "read".to_string(),
+            arguments: serde_json::json!({}),
+            reasoning: None,
+        };
+        let msg = turn_to_oai(&turn);
+        assert!(msg.content.is_none());
+        assert!(msg.tool_calls.is_some());
     }
 }
 // grcov-excl-stop

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -29,6 +29,10 @@ pub enum EntryContent {
         id: String,
         name: String,
         arguments: Value,
+        /// Text emitted by the model before the tool call (e.g. chain-of-thought).
+        /// Preserved so it can be replayed as part of the same assistant message.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reasoning: Option<String>,
     },
     ToolResult {
         tool_call_id: String,
@@ -154,6 +158,7 @@ mod tests {
                 id: "call_1".into(),
                 name: "read".into(),
                 arguments: serde_json::json!({ "file_path": "/LICENSE" }),
+                reasoning: None,
             },
         );
         mem.add_entry(


### PR DESCRIPTION
## Summary

Chain-of-thought text emitted before a tool call was being dropped or stored as a separate assistant message, which violates the Anthropic and OpenAI replay protocol (reasoning and the tool call must arrive in a single assistant message). This adds a `reasoning: Option<String>` field to `ConversationTurn::AssistantToolCall` and `EntryContent::ToolCall` so the text is captured and replayed alongside its tool call.

## Changes

- `crates/llm`: add `reasoning` field to `ConversationTurn::AssistantToolCall`
- `crates/memory`: add `reasoning` field to `EntryContent::ToolCall` (serde opt-in)
- `crates/llm/anthropic`: collect text block before `tool_use`; return both in one `LlmResponse`; emit text + tool_use blocks in correct order on replay
- `crates/llm/openai`: preserve `msg.content` as reasoning when a tool call is present; set `content` field alongside `tool_calls` on replay
- `crates/agent-loop`: skip standalone text memory entry when a tool call is present; store reasoning inside the `ToolCall` entry instead
- Tests: two new integration tests in `agent_loop_tests` + unit tests for both clients

Closes #22