### PR TITLE
feat(cli): stream TUI responses

### DIFF
--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -403,4 +403,39 @@ mod tests {
         );
         assert!(r.tool_call.is_some());
     }
+
+    #[test]
+    fn unknown_block_alone_returns_empty_response() {
+        let r = parse_blocks(&[ContentBlock::Unknown]);
+        assert!(r.content.is_none());
+        assert!(r.tool_call.is_none());
+    }
+
+    #[test]
+    fn unknown_block_mixed_with_text_is_skipped() {
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "thought".to_string(),
+            },
+            ContentBlock::Unknown,
+        ];
+        let r = parse_blocks(&blocks);
+        assert_eq!(r.content.as_deref(), Some("thought"));
+        assert!(r.tool_call.is_none());
+    }
+
+    #[test]
+    fn unknown_block_before_tool_use_is_skipped() {
+        let blocks = vec![
+            ContentBlock::Unknown,
+            ContentBlock::ToolUse {
+                id: "toolu_01".to_string(),
+                name: "read".to_string(),
+                input: serde_json::json!({}),
+            },
+        ];
+        let r = parse_blocks(&blocks);
+        assert!(r.content.is_none());
+        assert!(r.tool_call.is_some());
+    }
 }

--- a/justfile
+++ b/justfile
@@ -38,8 +38,8 @@ dev:
 coverage:
   mkdir -p coverage
   cargo llvm-cov --workspace --no-report
-  cargo llvm-cov report --lcov --output-path coverage/lcov
-  cargo llvm-cov report --html --output-dir coverage
+  cargo llvm-cov report --lcov --output-path coverage/lcov --ignore-filename-regex 'apps/cli/src/main\.rs'
+  cargo llvm-cov report --html --output-dir coverage --ignore-filename-regex 'apps/cli/src/main\.rs'
   printf "\n  %-50s  %8s  %-10s  %9s  %-10s\n" "File" "Lines" "(hit/tot)" "Functions" "(hit/tot)"
   printf "  %-50s  %8s  %-10s  %9s  %-10s\n" "--------------------------------------------------" "--------" "----------" "---------" "----------"
   awk -F: '\


### PR DESCRIPTION
## Summary

TUI runs should show assistant output as it streams instead of waiting for the final response. This wires token streaming through the agent loop and LLM clients, renders a newline-gated live tail in the TUI, and implements true streaming for both Anthropic and OpenAI while preserving streamed Unicode content across SSE chunk boundaries.

## Changes

- Add optional token streaming support through yaai-llm, yaai-agent-loop, and CLI runner paths
- Render live assistant tokens in the TUI with newline-gated buffering and final transcript completion
- Parse Anthropic streaming SSE chunks without corrupting UTF-8 split across response chunks
- Add true OpenAI chat-completions SSE streaming for text and tool-call deltas
- Add coverage for unknown Anthropic content blocks and split UTF-8 SSE lines
- Exclude apps/cli/src/main.rs from llvm-cov reports

## Testing

- just lint
- just test
- pre-push cargo llvm-cov --workspace --no-report coverage check