### PR TITLE
feat(cli): stream TUI responses

### DIFF
--- a/apps/cli/src/commands/prompt.rs
+++ b/apps/cli/src/commands/prompt.rs
@@ -95,7 +95,7 @@ pub async fn execute_non_interactive(args: &PromptArgs, cfg: &YaaiConfig) -> Res
         .prompt_text()?
         .ok_or_else(|| anyhow::anyhow!("prompt is required for non-interactive execution"))?;
     let resolved = args.resolve_run_args(cfg)?;
-    let (result, _memory) = run_prompt(&prompt, &resolved, SessionMemory::new()).await?;
+    let (result, _memory) = run_prompt(&prompt, &resolved, SessionMemory::new(), None).await?;
 
     info!(steps = result.steps_taken, "run complete");
     println!("{}", result.answer);

--- a/apps/cli/src/commands/runner.rs
+++ b/apps/cli/src/commands/runner.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use tokio::sync::mpsc;
 use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::LlmClient;
@@ -28,6 +29,7 @@ pub async fn run_prompt(
     prompt: &str,
     args: &ResolvedRunArgs,
     initial_memory: SessionMemory,
+    token_tx: Option<mpsc::UnboundedSender<String>>,
 ) -> Result<(PromptRunResult, SessionMemory)> {
     let (provider, model) = parse_provider_model(&args.model)?;
     let llm = build_llm_client(&provider, &model)?;
@@ -35,7 +37,15 @@ pub async fn run_prompt(
         Provider::OpenAi => ToolSchemaFormat::OpenAi,
         Provider::Anthropic => ToolSchemaFormat::Anthropic,
     };
-    run_prompt_with_client(prompt, args, llm.as_ref(), initial_memory, tool_format).await
+    run_prompt_with_client(
+        prompt,
+        args,
+        llm.as_ref(),
+        initial_memory,
+        tool_format,
+        token_tx,
+    )
+    .await
 }
 
 pub fn build_tool_registry() -> ToolRegistry {
@@ -52,6 +62,7 @@ pub async fn run_prompt_with_client(
     llm: &dyn LlmClient,
     initial_memory: SessionMemory,
     tool_format: ToolSchemaFormat,
+    token_tx: Option<mpsc::UnboundedSender<String>>,
 ) -> Result<(PromptRunResult, SessionMemory)> {
     let tools = build_tool_registry();
 
@@ -70,10 +81,13 @@ pub async fn run_prompt_with_client(
     };
     let tracer = Tracer::new(Uuid::new_v4(), &args.traces_dir)?;
 
-    let agent_result = AgentRunner::new(&agent_config, llm, &tools, &tracer, tool_format)
-        .with_memory(initial_memory)
-        .run(prompt)
-        .await;
+    let runner = AgentRunner::new(&agent_config, llm, &tools, &tracer, tool_format)
+        .with_memory(initial_memory);
+    let runner = match token_tx {
+        Some(tx) => runner.with_streaming(tx),
+        None => runner,
+    };
+    let agent_result = runner.run(prompt).await;
 
     let close_result = tracer.close().await;
 
@@ -125,6 +139,7 @@ mod tests {
             &llm,
             SessionMemory::new(),
             ToolSchemaFormat::OpenAi,
+            None,
         )
         .await
         .unwrap();
@@ -148,6 +163,7 @@ mod tests {
             &llm,
             SessionMemory::new(),
             ToolSchemaFormat::OpenAi,
+            None,
         )
         .await
         .unwrap_err();
@@ -164,7 +180,7 @@ mod tests {
             model: "bogus/model".to_string(),
             traces_dir: tempdir().unwrap().path().display().to_string(),
         };
-        let err = run_prompt("hi", &args, SessionMemory::new())
+        let err = run_prompt("hi", &args, SessionMemory::new(), None)
             .await
             .unwrap_err();
         assert!(err.to_string().to_lowercase().contains("provider"));

--- a/apps/cli/src/commands/tui/app.rs
+++ b/apps/cli/src/commands/tui/app.rs
@@ -28,6 +28,7 @@ pub(crate) struct TuiApp {
     pub(crate) session_memory: SessionMemory,
     result_rx: mpsc::UnboundedReceiver<RunResult>,
     result_tx: mpsc::UnboundedSender<RunResult>,
+    token_rx: mpsc::UnboundedReceiver<String>,
     active_task: Option<tokio::task::JoinHandle<()>>,
     /// `usize::MAX` means "pinned to bottom — auto-follow new content".
     scroll_offset: usize,
@@ -38,6 +39,7 @@ pub(crate) struct TuiApp {
 impl TuiApp {
     pub(crate) fn new(run_args: ResolvedRunArgs) -> Self {
         let (result_tx, result_rx) = mpsc::unbounded_channel();
+        let (_dummy_token_tx, token_rx) = mpsc::unbounded_channel::<String>();
 
         Self {
             state: AppState::default(),
@@ -46,6 +48,7 @@ impl TuiApp {
             session_memory: SessionMemory::new(),
             result_rx,
             result_tx,
+            token_rx,
             active_task: None,
             scroll_offset: usize::MAX,
             last_max_scroll: 0,
@@ -76,6 +79,11 @@ impl TuiApp {
     async fn event_loop(&mut self, terminal: &mut AppTerminal) -> Result<()> {
         let mut dirty = true;
         loop {
+            while let Ok(token) = self.token_rx.try_recv() {
+                self.state.append_token(token);
+                dirty = true;
+            }
+
             while let Ok(result) = self.result_rx.try_recv() {
                 self.process_run_result(result);
                 dirty = true;
@@ -86,7 +94,10 @@ impl TuiApp {
                 dirty = false;
             }
 
-            if event::poll(Duration::from_millis(50))? {
+            let has_event =
+                tokio::task::spawn_blocking(|| event::poll(Duration::from_millis(50))).await??;
+
+            if has_event {
                 let evt = event::read()?;
                 if self.handle_event(evt).await? {
                     return Ok(());
@@ -155,8 +166,10 @@ impl TuiApp {
             old.abort();
         }
         while self.result_rx.try_recv().is_ok() {}
+        let (token_tx, token_rx) = mpsc::unbounded_channel::<String>();
+        self.token_rx = token_rx;
         let handle = tokio::spawn(async move {
-            let result = run_prompt(&input, &run_args, memory_snapshot)
+            let result = run_prompt(&input, &run_args, memory_snapshot, Some(token_tx))
                 .await
                 .map_err(|e| e.to_string());
             let _ = tx.send(result);

--- a/apps/cli/src/commands/tui/state.rs
+++ b/apps/cli/src/commands/tui/state.rs
@@ -24,11 +24,50 @@ pub(crate) enum RunState {
     Running,
 }
 
+/// Newline-gated streaming buffer — mirrors the `MarkdownStreamCollector` pattern from codex.
+///
+/// Raw token deltas accumulate in `raw`. `committed_end` tracks the byte offset after the last
+/// `\n` in `raw`: everything before that offset is "committed" (safe to render as complete lines).
+/// The slice from `committed_end` to the end is the partial current line shown with a cursor.
+/// On finalisation the pending slice is flushed even without a trailing newline.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+struct StreamingBuffer {
+    raw: String,
+    committed_end: usize,
+}
+
+impl StreamingBuffer {
+    fn push(&mut self, token: &str) {
+        self.raw.push_str(token);
+        // Advance committed_end to after the last newline in the buffer.
+        if token.contains('\n') {
+            if let Some(idx) = self.raw.rfind('\n') {
+                self.committed_end = idx + 1;
+            }
+        }
+    }
+
+    fn committed(&self) -> &str {
+        &self.raw[..self.committed_end]
+    }
+
+    fn pending(&self) -> &str {
+        &self.raw[self.committed_end..]
+    }
+
+    fn clear(&mut self) {
+        self.raw.clear();
+        self.committed_end = 0;
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct AppState {
     pub(crate) transcript: Vec<TranscriptEntry>,
     pub(crate) status: String,
     pub(crate) run_state: RunState,
+    streaming: StreamingBuffer,
+    streaming_active: bool,
 }
 
 impl Default for AppState {
@@ -37,6 +76,8 @@ impl Default for AppState {
             transcript: Vec::new(),
             status: "Ready. Enter submits, Shift+Enter adds a newline, PageUp/PageDown scrolls, Ctrl+C exits.".to_string(),
             run_state: RunState::Idle,
+            streaming: StreamingBuffer::default(),
+            streaming_active: false,
         }
     }
 }
@@ -53,9 +94,23 @@ impl AppState {
         });
         self.status = "Running agent...".to_string();
         self.run_state = RunState::Running;
+        self.streaming.clear();
+        self.streaming_active = true;
+    }
+
+    /// Push a raw token delta into the newline-gated buffer.
+    ///
+    /// Tokens accumulate in `streaming.raw`. `committed_end` advances only when a `\n`
+    /// arrives, so partial lines are held back and never rendered mid-character — matching
+    /// the codex `MarkdownStreamCollector` contract.  The partial current line is always
+    /// shown with a `▊` cursor so the user sees progress within a line too.
+    pub(crate) fn append_token(&mut self, token: String) {
+        self.streaming.push(&token);
     }
 
     pub(crate) fn complete_run(&mut self, result: Result<PromptRunResult, String>) {
+        self.streaming.clear();
+        self.streaming_active = false;
         match result {
             Ok(result) => {
                 self.transcript.push(TranscriptEntry {
@@ -83,7 +138,7 @@ impl AppState {
     }
 
     pub(crate) fn transcript_text(&self) -> Text<'static> {
-        if self.transcript.is_empty() {
+        if self.transcript.is_empty() && !self.streaming_active {
             return Text::from(vec![Line::from(
                 "No messages yet. Type a prompt below to start a run.",
             )]);
@@ -113,6 +168,52 @@ impl AppState {
                 }
             }
             lines.push(Line::from(""));
+        }
+
+        // Streaming live tail — newline-gated, matching codex MarkdownStreamCollector semantics:
+        //
+        // Committed source (everything up to the last \n) is rendered as stable complete lines.
+        // The pending slice (partial current line) is rendered separately with a block cursor so
+        // the user sees in-line progress without exposing mid-line content as a completed row.
+        if self.streaming_active {
+            let committed = self.streaming.committed();
+            let pending = self.streaming.pending();
+
+            // Render committed lines (newline-terminated, stable).
+            let mut first_streaming_line = true;
+            for sub in committed.split('\n') {
+                // split('\n') on "a\nb\n" → ["a", "b", ""] — skip the trailing empty
+                if sub.is_empty() && !first_streaming_line {
+                    continue;
+                }
+                if first_streaming_line {
+                    lines.push(Line::from(vec![
+                        Span::styled(
+                            "Assistant: ".to_string(),
+                            Style::default().add_modifier(Modifier::BOLD),
+                        ),
+                        Span::raw(sub.to_string()),
+                    ]));
+                    first_streaming_line = false;
+                } else {
+                    lines.push(Line::from(Span::raw(sub.to_string())));
+                }
+            }
+
+            // Render pending partial line with cursor.
+            let cursor_line = format!("{}▊", pending);
+            if first_streaming_line {
+                // Nothing committed yet — pending is the first visible line.
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        "Assistant: ".to_string(),
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(cursor_line),
+                ]));
+            } else {
+                lines.push(Line::from(Span::raw(cursor_line)));
+            }
         }
 
         Text::from(lines)

--- a/apps/cli/src/commands/tui/state.rs
+++ b/apps/cli/src/commands/tui/state.rs
@@ -182,8 +182,10 @@ impl AppState {
             // Render committed lines (newline-terminated, stable).
             let mut first_streaming_line = true;
             for sub in committed.split('\n') {
-                // split('\n') on "a\nb\n" → ["a", "b", ""] — skip the trailing empty
-                if sub.is_empty() && !first_streaming_line {
+                // split('\n') on "a\nb\n" → ["a", "b", ""] — skip all empty segments,
+                // including the sole "" produced by splitting an empty committed string
+                // before any newline has arrived.
+                if sub.is_empty() {
                     continue;
                 }
                 if first_streaming_line {

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -5,6 +5,7 @@
 
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
 use yaai_llm::{ConversationTurn, LlmClient, Message};
@@ -46,6 +47,7 @@ pub struct AgentRunner<'a> {
     tracer: &'a Tracer,
     memory: SessionMemory,
     tool_format: ToolSchemaFormat,
+    token_tx: Option<mpsc::UnboundedSender<String>>,
 }
 
 impl<'a> AgentRunner<'a> {
@@ -63,6 +65,16 @@ impl<'a> AgentRunner<'a> {
             tracer,
             memory: SessionMemory::new(),
             tool_format,
+            token_tx: None,
+        }
+    }
+
+    /// Enable token streaming. Text deltas are sent to `tx` as they arrive
+    /// from the LLM; the full [`LlmResponse`] is still returned as normal.
+    pub fn with_streaming(self, tx: mpsc::UnboundedSender<String>) -> Self {
+        Self {
+            token_tx: Some(tx),
+            ..self
         }
     }
 
@@ -132,10 +144,23 @@ impl<'a> AgentRunner<'a> {
                 serde_json::json!({ "turn_count": turns.len() }),
             )?;
 
-            let response = self
-                .llm
-                .complete(Some(&self.config.system_prompt), &turns, &tool_descriptors)
-                .await?;
+            let response = match self.token_tx.as_ref() {
+                Some(tx) => {
+                    self.llm
+                        .complete_streaming(
+                            Some(&self.config.system_prompt),
+                            &turns,
+                            &tool_descriptors,
+                            tx,
+                        )
+                        .await?
+                }
+                None => {
+                    self.llm
+                        .complete(Some(&self.config.system_prompt), &turns, &tool_descriptors)
+                        .await?
+                }
+            };
 
             if response.content.is_none() && response.tool_call.is_none() {
                 let msg = format!(

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::mpsc;
 use tracing::debug;
 
 use crate::{ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
@@ -58,6 +59,8 @@ struct MessagesRequest<'a> {
     messages: Vec<AnthropicMessage>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     tools: &'a [Value],
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    stream: bool,
 }
 
 /// A single message in the Anthropic wire format. Content is always a list of
@@ -103,6 +106,61 @@ enum ContentBlock {
     },
     #[serde(other)]
     Unknown,
+}
+
+// ── Streaming SSE event types ────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum StreamEvent {
+    ContentBlockStart {
+        #[allow(dead_code)]
+        index: usize,
+        content_block: StreamBlock,
+    },
+    ContentBlockDelta {
+        #[allow(dead_code)]
+        index: usize,
+        delta: StreamDelta,
+    },
+    Error {
+        error: StreamApiError,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum StreamBlock {
+    Text {
+        #[allow(dead_code)]
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum StreamDelta {
+    TextDelta {
+        text: String,
+    },
+    InputJsonDelta {
+        partial_json: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+struct StreamApiError {
+    message: String,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -191,6 +249,24 @@ fn parse_blocks(blocks: &[ContentBlock]) -> LlmResponse {
     }
 }
 
+fn pop_sse_line(buf: &mut Vec<u8>) -> Result<Option<String>> {
+    let Some(pos) = buf.iter().position(|byte| *byte == b'\n') else {
+        return Ok(None);
+    };
+
+    let mut line: Vec<u8> = buf.drain(..=pos).collect();
+    if line.last() == Some(&b'\n') {
+        line.pop();
+    }
+    if line.last() == Some(&b'\r') {
+        line.pop();
+    }
+
+    String::from_utf8(line)
+        .context("decoding SSE line from Anthropic stream")
+        .map(Some)
+}
+
 #[async_trait]
 impl LlmClient for AnthropicClient {
     async fn complete(
@@ -209,6 +285,7 @@ impl LlmClient for AnthropicClient {
             system,
             messages,
             tools,
+            stream: false,
         };
 
         let response = self
@@ -233,6 +310,102 @@ impl LlmClient for AnthropicClient {
             .context("parsing Anthropic response")?;
 
         Ok(parse_blocks(&resp.content))
+    }
+
+    async fn complete_streaming(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+        tx: &mpsc::UnboundedSender<String>,
+    ) -> Result<LlmResponse> {
+        debug!(model = %self.model, turns = turns.len(), "calling Anthropic (streaming)");
+
+        let messages: Vec<AnthropicMessage> = turns.iter().map(turn_to_anthropic).collect();
+
+        let body = MessagesRequest {
+            model: &self.model,
+            max_tokens: DEFAULT_MAX_TOKENS,
+            system,
+            messages,
+            tools,
+            stream: true,
+        };
+
+        let mut response = self
+            .client
+            .post(ANTHROPIC_API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", ANTHROPIC_VERSION)
+            .json(&body)
+            .send()
+            .await
+            .context("sending streaming request to Anthropic")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("Anthropic API error ({}): {}", status, body);
+        }
+
+        let mut buf = Vec::new();
+        let mut text = String::new();
+        let mut tool_id: Option<String> = None;
+        let mut tool_name: Option<String> = None;
+        let mut tool_json = String::new();
+
+        while let Some(chunk) = response.chunk().await.context("reading SSE stream")? {
+            buf.extend_from_slice(&chunk);
+
+            while let Some(line) = pop_sse_line(&mut buf)? {
+                let Some(data) = line.strip_prefix("data: ") else {
+                    continue;
+                };
+
+                match serde_json::from_str::<StreamEvent>(data) {
+                    Ok(StreamEvent::ContentBlockStart { content_block, .. }) => {
+                        if let StreamBlock::ToolUse { id, name } = content_block {
+                            tool_id = Some(id);
+                            tool_name = Some(name);
+                        }
+                    }
+                    Ok(StreamEvent::ContentBlockDelta { delta, .. }) => match delta {
+                        StreamDelta::TextDelta { text: t } => {
+                            let _ = tx.send(t.clone());
+                            text.push_str(&t);
+                        }
+                        StreamDelta::InputJsonDelta { partial_json } => {
+                            tool_json.push_str(&partial_json);
+                        }
+                        StreamDelta::Other => {}
+                    },
+                    Ok(StreamEvent::Error { error }) => {
+                        bail!("Anthropic stream error: {}", error.message);
+                    }
+                    Ok(StreamEvent::Other) | Err(_) => {}
+                }
+            }
+        }
+
+        let tool_call = match (tool_id, tool_name) {
+            (Some(id), Some(name)) => {
+                let arguments = if tool_json.is_empty() {
+                    serde_json::json!({})
+                } else {
+                    serde_json::from_str(&tool_json).context("parsing tool input JSON")?
+                };
+                Some(ToolCall {
+                    id,
+                    name,
+                    arguments,
+                })
+            }
+            _ => None,
+        };
+
+        let content = if text.is_empty() { None } else { Some(text) };
+
+        Ok(LlmResponse { content, tool_call })
     }
 }
 
@@ -312,6 +485,7 @@ mod tests {
             system: None,
             messages: vec![],
             tools: &[],
+            stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_none(), "empty tools must be omitted");
@@ -326,9 +500,27 @@ mod tests {
             system: None,
             messages: vec![],
             tools: &tools,
+            stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_some());
+    }
+
+    #[test]
+    fn sse_line_buffer_preserves_utf8_split_across_chunks() {
+        let line = "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi 😀\"}}\n";
+        let split = line.find('😀').unwrap() + 1;
+        let bytes = line.as_bytes();
+        let mut buf = Vec::new();
+
+        buf.extend_from_slice(&bytes[..split]);
+        assert_eq!(pop_sse_line(&mut buf).unwrap(), None);
+
+        buf.extend_from_slice(&bytes[split..]);
+        assert_eq!(
+            pop_sse_line(&mut buf).unwrap().as_deref(),
+            Some(line.trim_end_matches('\n'))
+        );
     }
 
     #[test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -13,6 +13,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::mpsc;
 
 /// Build a [`reqwest::Client`] with sensible defaults: 10 s connect timeout,
 /// 120 s overall request timeout.
@@ -136,6 +137,23 @@ pub trait LlmClient: Send + Sync {
         turns: &[ConversationTurn],
         tools: &[Value],
     ) -> Result<LlmResponse>;
+
+    /// Stream token deltas to `tx` as they arrive, returning the full response
+    /// once complete. The default implementation calls [`complete`] and emits
+    /// the entire content as a single token.
+    async fn complete_streaming(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+        tx: &mpsc::UnboundedSender<String>,
+    ) -> Result<LlmResponse> {
+        let response = self.complete(system, turns, tools).await?;
+        if let Some(ref text) = response.content {
+            let _ = tx.send(text.clone());
+        }
+        Ok(response)
+    }
 }
 
 #[async_trait]
@@ -147,5 +165,15 @@ impl LlmClient for Box<dyn LlmClient> {
         tools: &[Value],
     ) -> Result<LlmResponse> {
         (**self).complete(system, turns, tools).await
+    }
+
+    async fn complete_streaming(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+        tx: &mpsc::UnboundedSender<String>,
+    ) -> Result<LlmResponse> {
+        (**self).complete_streaming(system, turns, tools, tx).await
     }
 }

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -4,9 +4,12 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use tokio::sync::mpsc;
 use tracing::debug;
 
 use crate::{ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
+
+const OPENAI_CHAT_COMPLETIONS_URL: &str = "https://api.openai.com/v1/chat/completions";
 
 #[derive(Debug, Clone)]
 pub struct OpenAiClient {
@@ -43,6 +46,8 @@ struct ChatRequest<'a> {
     messages: Vec<OaiMessage>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     tools: &'a [Value],
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    stream: bool,
 }
 
 /// A single message in the OpenAI wire format.
@@ -102,7 +107,61 @@ struct OaiInboundFunction {
     arguments: String,
 }
 
+// ── Streaming SSE event types ────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct ChatStreamResponse {
+    choices: Vec<StreamChoice>,
+}
+
+#[derive(Deserialize)]
+struct StreamChoice {
+    delta: StreamDelta,
+}
+
+#[derive(Deserialize)]
+struct StreamDelta {
+    content: Option<String>,
+    tool_calls: Option<Vec<OaiStreamToolCall>>,
+}
+
+#[derive(Deserialize)]
+struct OaiStreamToolCall {
+    id: Option<String>,
+    function: Option<OaiStreamFunction>,
+}
+
+#[derive(Deserialize)]
+struct OaiStreamFunction {
+    name: Option<String>,
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Default)]
+struct StreamAccumulator {
+    text: String,
+    tool_id: Option<String>,
+    tool_name: Option<String>,
+    tool_arguments: String,
+}
+
 // ─────────────────────────────────────────────────────────────────────────────
+
+fn build_messages(system: Option<&str>, turns: &[ConversationTurn]) -> Vec<OaiMessage> {
+    let mut messages: Vec<OaiMessage> = turns.iter().map(turn_to_oai).collect();
+    if let Some(sys) = system {
+        messages.insert(
+            0,
+            OaiMessage {
+                role: "system",
+                content: Some(sys.to_string()),
+                tool_calls: None,
+                tool_call_id: None,
+            },
+        );
+    }
+    messages
+}
 
 fn turn_to_oai(turn: &ConversationTurn) -> OaiMessage {
     match turn {
@@ -146,6 +205,89 @@ fn turn_to_oai(turn: &ConversationTurn) -> OaiMessage {
     }
 }
 
+fn pop_sse_line(buf: &mut Vec<u8>) -> Result<Option<String>> {
+    let Some(pos) = buf.iter().position(|byte| *byte == b'\n') else {
+        return Ok(None);
+    };
+
+    let mut line: Vec<u8> = buf.drain(..=pos).collect();
+    if line.last() == Some(&b'\n') {
+        line.pop();
+    }
+    if line.last() == Some(&b'\r') {
+        line.pop();
+    }
+
+    String::from_utf8(line)
+        .context("decoding SSE line from OpenAI stream")
+        .map(Some)
+}
+
+fn apply_stream_data(
+    data: &str,
+    tx: &mpsc::UnboundedSender<String>,
+    accumulator: &mut StreamAccumulator,
+) -> Result<()> {
+    if data == "[DONE]" {
+        return Ok(());
+    }
+
+    let event: ChatStreamResponse =
+        serde_json::from_str(data).context("parsing OpenAI stream event")?;
+
+    for choice in event.choices {
+        if let Some(text) = choice.delta.content {
+            let _ = tx.send(text.clone());
+            accumulator.text.push_str(&text);
+        }
+
+        if let Some(tool_calls) = choice.delta.tool_calls {
+            for tool_call in tool_calls {
+                if let Some(id) = tool_call.id {
+                    accumulator.tool_id = Some(id);
+                }
+                if let Some(function) = tool_call.function {
+                    if let Some(name) = function.name {
+                        accumulator.tool_name = Some(name);
+                    }
+                    if let Some(arguments) = function.arguments {
+                        accumulator.tool_arguments.push_str(&arguments);
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn accumulated_response(accumulator: StreamAccumulator) -> Result<LlmResponse> {
+    let tool_call = match (accumulator.tool_id, accumulator.tool_name) {
+        (Some(id), Some(name)) => {
+            let arguments = if accumulator.tool_arguments.is_empty() {
+                serde_json::json!({})
+            } else {
+                serde_json::from_str(&accumulator.tool_arguments)
+                    .context("parsing streamed tool call arguments")?
+            };
+            Some(ToolCall {
+                id,
+                name,
+                arguments,
+            })
+        }
+        _ => None,
+    };
+
+    let content = if accumulator.text.is_empty() {
+        None
+    } else {
+        Some(accumulator.text)
+    };
+
+    Ok(LlmResponse { content, tool_call })
+}
+
 #[async_trait]
 impl LlmClient for OpenAiClient {
     async fn complete(
@@ -157,28 +299,18 @@ impl LlmClient for OpenAiClient {
         debug!(model = %self.model, turns = turns.len(), "calling OpenAI");
 
         // OpenAI expects the system prompt as the first entry in the messages array.
-        let mut messages: Vec<OaiMessage> = turns.iter().map(turn_to_oai).collect();
-        if let Some(sys) = system {
-            messages.insert(
-                0,
-                OaiMessage {
-                    role: "system",
-                    content: Some(sys.to_string()),
-                    tool_calls: None,
-                    tool_call_id: None,
-                },
-            );
-        }
+        let messages = build_messages(system, turns);
 
         let body = ChatRequest {
             model: &self.model,
             messages,
             tools,
+            stream: false,
         };
 
         let response = self
             .client
-            .post("https://api.openai.com/v1/chat/completions")
+            .post(OPENAI_CHAT_COMPLETIONS_URL)
             .bearer_auth(&self.api_key)
             .json(&body)
             .send()
@@ -219,6 +351,60 @@ impl LlmClient for OpenAiClient {
             content: msg.content,
             tool_call: None,
         })
+    }
+
+    async fn complete_streaming(
+        &self,
+        system: Option<&str>,
+        turns: &[ConversationTurn],
+        tools: &[Value],
+        tx: &mpsc::UnboundedSender<String>,
+    ) -> Result<LlmResponse> {
+        debug!(model = %self.model, turns = turns.len(), "calling OpenAI (streaming)");
+
+        let messages = build_messages(system, turns);
+        let body = ChatRequest {
+            model: &self.model,
+            messages,
+            tools,
+            stream: true,
+        };
+
+        let mut response = self
+            .client
+            .post(OPENAI_CHAT_COMPLETIONS_URL)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await
+            .context("sending streaming request to OpenAI")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            bail!("OpenAI API error ({}): {}", status, body);
+        }
+
+        let mut buf = Vec::new();
+        let mut accumulator = StreamAccumulator::default();
+
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .context("reading OpenAI SSE stream")?
+        {
+            buf.extend_from_slice(&chunk);
+
+            while let Some(line) = pop_sse_line(&mut buf)? {
+                let Some(data) = line.strip_prefix("data: ") else {
+                    continue;
+                };
+
+                apply_stream_data(data, tx, &mut accumulator)?;
+            }
+        }
+
+        accumulated_response(accumulator)
     }
 }
 
@@ -297,6 +483,7 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &[],
+            stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_none(), "empty tools must be omitted");
@@ -309,9 +496,90 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &tools,
+            stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_some());
+    }
+
+    #[test]
+    fn stream_true_is_included_in_request_json() {
+        let req = ChatRequest {
+            model: "gpt-test",
+            messages: vec![],
+            tools: &[],
+            stream: true,
+        };
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["stream"], true);
+    }
+
+    #[test]
+    fn sse_line_buffer_preserves_utf8_split_across_chunks() {
+        let line = "data: {\"choices\":[{\"delta\":{\"content\":\"hello 😀\"}}]}\n";
+        let split = line.find('😀').unwrap() + 1;
+        let bytes = line.as_bytes();
+        let mut buf = Vec::new();
+
+        buf.extend_from_slice(&bytes[..split]);
+        assert_eq!(pop_sse_line(&mut buf).unwrap(), None);
+
+        buf.extend_from_slice(&bytes[split..]);
+        assert_eq!(
+            pop_sse_line(&mut buf).unwrap().as_deref(),
+            Some(line.trim_end_matches('\n'))
+        );
+    }
+
+    #[test]
+    fn stream_data_accumulates_text_and_emits_deltas() {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let mut accumulator = StreamAccumulator::default();
+
+        apply_stream_data(
+            "{\"choices\":[{\"delta\":{\"content\":\"hello \"}}]}",
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+        apply_stream_data(
+            "{\"choices\":[{\"delta\":{\"content\":\"world\"}}]}",
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+
+        assert_eq!(rx.try_recv().unwrap(), "hello ");
+        assert_eq!(rx.try_recv().unwrap(), "world");
+        let response = accumulated_response(accumulator).unwrap();
+        assert_eq!(response.content.as_deref(), Some("hello world"));
+        assert!(response.tool_call.is_none());
+    }
+
+    #[test]
+    fn stream_data_accumulates_tool_call_arguments() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut accumulator = StreamAccumulator::default();
+
+        apply_stream_data(
+            "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"id\":\"call_01\",\"type\":\"function\",\"function\":{\"name\":\"read\",\"arguments\":\"{\\\"file_path\\\":\"}}]}}]}",
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+        apply_stream_data(
+            "{\"choices\":[{\"delta\":{\"tool_calls\":[{\"index\":0,\"function\":{\"arguments\":\"\\\"/tmp/a.txt\\\"}\"}}]}}]}",
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+
+        let response = accumulated_response(accumulator).unwrap();
+        assert!(response.content.is_none());
+        let tool_call = response.tool_call.unwrap();
+        assert_eq!(tool_call.id, "call_01");
+        assert_eq!(tool_call.name, "read");
+        assert_eq!(tool_call.arguments["file_path"], "/tmp/a.txt");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

TUI runs should show assistant output as it streams instead of waiting for the final response. This wires token streaming through the agent loop and LLM clients, renders a newline-gated live tail in the TUI, and implements true streaming for both Anthropic and OpenAI while preserving streamed Unicode content across SSE chunk boundaries.

## Changes

- Add optional token streaming support through yaai-llm, yaai-agent-loop, and CLI runner paths
- Render live assistant tokens in the TUI with newline-gated buffering and final transcript completion
- Parse Anthropic streaming SSE chunks without corrupting UTF-8 split across response chunks
- Add true OpenAI chat-completions SSE streaming for text and tool-call deltas
- Add split UTF-8 SSE coverage for both Anthropic and OpenAI streaming parsers

## Testing

- just lint
- just test
- pre-push cargo llvm-cov --workspace --no-report coverage check