### PR TITLE
refactor(llm): extract pop_sse_line into shared sse module

### DIFF
--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use crate::{ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
+use crate::{sse::pop_sse_line, ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_VERSION: &str = "2023-06-01";
@@ -249,24 +249,6 @@ fn parse_blocks(blocks: &[ContentBlock]) -> LlmResponse {
     }
 }
 
-fn pop_sse_line(buf: &mut Vec<u8>) -> Result<Option<String>> {
-    let Some(pos) = buf.iter().position(|byte| *byte == b'\n') else {
-        return Ok(None);
-    };
-
-    let mut line: Vec<u8> = buf.drain(..=pos).collect();
-    if line.last() == Some(&b'\n') {
-        line.pop();
-    }
-    if line.last() == Some(&b'\r') {
-        line.pop();
-    }
-
-    String::from_utf8(line)
-        .context("decoding SSE line from Anthropic stream")
-        .map(Some)
-}
-
 #[async_trait]
 impl LlmClient for AnthropicClient {
     async fn complete(
@@ -504,23 +486,6 @@ mod tests {
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_some());
-    }
-
-    #[test]
-    fn sse_line_buffer_preserves_utf8_split_across_chunks() {
-        let line = "data: {\"type\":\"content_block_delta\",\"index\":0,\"delta\":{\"type\":\"text_delta\",\"text\":\"hi 😀\"}}\n";
-        let split = line.find('😀').unwrap() + 1;
-        let bytes = line.as_bytes();
-        let mut buf = Vec::new();
-
-        buf.extend_from_slice(&bytes[..split]);
-        assert_eq!(pop_sse_line(&mut buf).unwrap(), None);
-
-        buf.extend_from_slice(&bytes[split..]);
-        assert_eq!(
-            pop_sse_line(&mut buf).unwrap().as_deref(),
-            Some(line.trim_end_matches('\n'))
-        );
     }
 
     #[test]

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -7,6 +7,7 @@
 
 pub mod anthropic;
 pub mod openai;
+mod sse;
 pub mod stub;
 
 use anyhow::Result;

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tracing::debug;
 
-use crate::{ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
+use crate::{sse::pop_sse_line, ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
 const OPENAI_CHAT_COMPLETIONS_URL: &str = "https://api.openai.com/v1/chat/completions";
 
@@ -203,24 +203,6 @@ fn turn_to_oai(turn: &ConversationTurn) -> OaiMessage {
             tool_call_id: Some(tool_call_id.clone()),
         },
     }
-}
-
-fn pop_sse_line(buf: &mut Vec<u8>) -> Result<Option<String>> {
-    let Some(pos) = buf.iter().position(|byte| *byte == b'\n') else {
-        return Ok(None);
-    };
-
-    let mut line: Vec<u8> = buf.drain(..=pos).collect();
-    if line.last() == Some(&b'\n') {
-        line.pop();
-    }
-    if line.last() == Some(&b'\r') {
-        line.pop();
-    }
-
-    String::from_utf8(line)
-        .context("decoding SSE line from OpenAI stream")
-        .map(Some)
 }
 
 fn apply_stream_data(
@@ -512,23 +494,6 @@ mod tests {
         };
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["stream"], true);
-    }
-
-    #[test]
-    fn sse_line_buffer_preserves_utf8_split_across_chunks() {
-        let line = "data: {\"choices\":[{\"delta\":{\"content\":\"hello 😀\"}}]}\n";
-        let split = line.find('😀').unwrap() + 1;
-        let bytes = line.as_bytes();
-        let mut buf = Vec::new();
-
-        buf.extend_from_slice(&bytes[..split]);
-        assert_eq!(pop_sse_line(&mut buf).unwrap(), None);
-
-        buf.extend_from_slice(&bytes[split..]);
-        assert_eq!(
-            pop_sse_line(&mut buf).unwrap().as_deref(),
-            Some(line.trim_end_matches('\n'))
-        );
     }
 
     #[test]

--- a/crates/llm/src/sse.rs
+++ b/crates/llm/src/sse.rs
@@ -1,0 +1,47 @@
+//! Shared SSE stream utilities.
+
+use anyhow::{Context, Result};
+
+/// Pop one complete line from a byte buffer of SSE data.
+///
+/// Returns `None` when no newline has arrived yet (caller should buffer more
+/// bytes). Strips the trailing `\r\n` or `\n`.
+pub(crate) fn pop_sse_line(buf: &mut Vec<u8>) -> Result<Option<String>> {
+    let Some(pos) = buf.iter().position(|byte| *byte == b'\n') else {
+        return Ok(None);
+    };
+
+    let mut line: Vec<u8> = buf.drain(..=pos).collect();
+    if line.last() == Some(&b'\n') {
+        line.pop();
+    }
+    if line.last() == Some(&b'\r') {
+        line.pop();
+    }
+
+    String::from_utf8(line)
+        .context("decoding SSE line")
+        .map(Some)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sse_line_buffer_preserves_utf8_split_across_chunks() {
+        let line = "data: hello 😀\n";
+        let split = line.find('😀').unwrap() + 1;
+        let bytes = line.as_bytes();
+        let mut buf = Vec::new();
+
+        buf.extend_from_slice(&bytes[..split]);
+        assert_eq!(pop_sse_line(&mut buf).unwrap(), None);
+
+        buf.extend_from_slice(&bytes[split..]);
+        assert_eq!(
+            pop_sse_line(&mut buf).unwrap().as_deref(),
+            Some(line.trim_end_matches('\n'))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`pop_sse_line` was duplicated identically in `anthropic.rs` and `openai.rs`, meaning a bug fix would need to land in two places. Moves it to a new `crates/llm/src/sse.rs` module so there is a single source of truth, and consolidates the two identical tests into one.

## Changes

- Add `crates/llm/src/sse.rs` with `pub(crate) fn pop_sse_line`
- Remove duplicate `pop_sse_line` from `anthropic.rs` and `openai.rs`
- Remove duplicate `sse_line_buffer_preserves_utf8_split_across_chunks` tests from both files; one canonical test lives in `sse::tests`

Closes #27