### PR TITLE
feat(tools): add grep_files tool for regex content search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,6 +311,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +472,24 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
 
 [[package]]
 name = "equivalent"
@@ -589,6 +637,98 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308ae749734e28d749a86f33212c7b756748568ce332f970ac1d9cd8531f32e6"
+dependencies = [
+ "grep-cli",
+ "grep-matcher",
+ "grep-printer",
+ "grep-regex",
+ "grep-searcher",
+]
+
+[[package]]
+name = "grep-cli"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf32d263c5d5cc2a23ce587097f5ddafdb188492ba2e6fb638eaccdc22453631"
+dependencies = [
+ "bstr",
+ "globset",
+ "libc",
+ "log",
+ "termcolor",
+ "winapi-util",
+]
+
+[[package]]
+name = "grep-matcher"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "grep-printer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c112110ae4a891aa4d83ab82ecf734b307497d066f437686175e83fbd4e013fe"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "grep-searcher",
+ "log",
+ "serde",
+ "serde_json",
+ "termcolor",
+]
+
+[[package]]
+name = "grep-regex"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce0c256c3ad82bcc07b812c15a45ec1d398122e8e15124f96695234db7112ef"
+dependencies = [
+ "bstr",
+ "grep-matcher",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "grep-searcher"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac63295322dc48ebb20a25348147905d816318888e64f531bfc2a2bc0577dc34"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "encoding_rs_io",
+ "grep-matcher",
+ "log",
+ "memchr",
+ "memmap2",
 ]
 
 [[package]]
@@ -853,6 +993,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d782a365a015e0f5c04902246139249abf769125006fbe7649e2ee88169b4a"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1044,6 +1200,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memoffset"
@@ -1577,6 +1742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schemars"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,6 +2095,15 @@ dependencies = [
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2397,6 +2580,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2562,6 +2755,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"
@@ -2997,6 +3199,10 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "grep",
+ "grep-regex",
+ "grep-searcher",
+ "ignore",
  "schemars",
  "serde",
  "serde_json",

--- a/apps/cli/src/commands/runner.rs
+++ b/apps/cli/src/commands/runner.rs
@@ -4,7 +4,7 @@ use uuid::Uuid;
 use yaai_agent_loop::{AgentConfig, AgentRunner};
 use yaai_llm::LlmClient;
 use yaai_memory::SessionMemory;
-use yaai_tools::{ReadTool, ToolRegistry, ToolSchemaFormat};
+use yaai_tools::{GrepFilesTool, ReadTool, ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::Tracer;
 
 use super::llm::{build_llm_client, parse_provider_model, Provider};
@@ -49,7 +49,9 @@ pub async fn run_prompt(
 }
 
 pub fn build_tool_registry() -> ToolRegistry {
-    ToolRegistry::new().register(ReadTool::new())
+    ToolRegistry::new()
+        .register(ReadTool::new())
+        .register(GrepFilesTool::new())
 }
 
 /// Run a prompt, returning the result and the updated conversation history.
@@ -121,6 +123,15 @@ mod tests {
         assert!(
             registry.names().contains(&"read"),
             "expected 'read' tool to be registered"
+        );
+    }
+
+    #[test]
+    fn build_tool_registry_includes_grep_files_tool() {
+        let registry = build_tool_registry();
+        assert!(
+            registry.names().contains(&"grep_files"),
+            "expected 'grep_files' tool to be registered"
         );
     }
 

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -12,7 +12,6 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
-grep = "0.3"
 grep-regex = "0.1"
 grep-searcher = "0.1"
 ignore = "0.4"

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -12,6 +12,10 @@ async-trait = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 thiserror = { workspace = true }
+grep = "0.3"
+grep-regex = "0.1"
+grep-searcher = "0.1"
+ignore = "0.4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/tools/src/builtin/grep_files.rs
+++ b/crates/tools/src/builtin/grep_files.rs
@@ -7,6 +7,8 @@ use ignore::WalkBuilder;
 use schemars::{schema_for, JsonSchema};
 use serde::Deserialize;
 use serde_json::Value;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
@@ -163,7 +165,9 @@ fn search_files(
     }
 
     let mut searcher = SearcherBuilder::new().build();
-    let mut matches: Vec<(PathBuf, SystemTime)> = Vec::new();
+    // Min-heap keyed by Reverse<mtime>: peek() yields the oldest entry, enabling O(limit) memory.
+    let mut heap: BinaryHeap<(Reverse<SystemTime>, PathBuf)> = BinaryHeap::new();
+    let mut total = 0usize;
 
     for entry in walk_builder.build() {
         let entry = match entry {
@@ -179,22 +183,27 @@ fn search_files(
             continue;
         }
         if sink.matched {
+            total += 1;
             let mtime = path
                 .metadata()
                 .and_then(|m| m.modified())
                 .unwrap_or(SystemTime::UNIX_EPOCH);
             let rel = path.strip_prefix(working_dir).unwrap_or(path).to_path_buf();
-            matches.push((rel, mtime));
+            if heap.len() < limit {
+                heap.push((Reverse(mtime), rel));
+            } else if heap.peek().is_some_and(|(rev_t, _)| mtime > rev_t.0) {
+                heap.pop();
+                heap.push((Reverse(mtime), rel));
+            }
         }
     }
 
-    matches.sort_by(|a, b| b.1.cmp(&a.1));
-    let total = matches.len();
     let truncated = total > limit;
-    let files: Vec<String> = matches
+    let mut sorted: Vec<(Reverse<SystemTime>, PathBuf)> = heap.into_vec();
+    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+    let files: Vec<String> = sorted
         .into_iter()
-        .take(limit)
-        .map(|(p, _)| p.to_string_lossy().into_owned())
+        .map(|(_, p)| p.to_string_lossy().into_owned())
         .collect();
 
     Ok(serde_json::json!({

--- a/crates/tools/src/builtin/grep_files.rs
+++ b/crates/tools/src/builtin/grep_files.rs
@@ -1,0 +1,373 @@
+use crate::{Tool, ToolError};
+use async_trait::async_trait;
+use grep_regex::RegexMatcher;
+use grep_searcher::{SearcherBuilder, Sink, SinkMatch};
+use ignore::overrides::OverrideBuilder;
+use ignore::WalkBuilder;
+use schemars::{schema_for, JsonSchema};
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+const DEFAULT_LIMIT: usize = 50;
+
+#[derive(Debug, Deserialize, JsonSchema)]
+struct GrepFilesInput {
+    /// Regular expression to match against file contents.
+    pattern: String,
+    /// Directory or file to search. Defaults to session working directory.
+    path: Option<String>,
+    /// Glob to restrict which files are searched (e.g. "*.rs", "*.{ts,tsx}").
+    include: Option<String>,
+    /// Maximum number of file paths to return. Defaults to 50.
+    limit: Option<usize>,
+}
+
+#[derive(Clone)]
+pub struct GrepFilesTool {
+    working_dir: PathBuf,
+}
+
+impl GrepFilesTool {
+    pub fn new() -> Self {
+        Self::with_working_dir(std::env::current_dir().unwrap_or_default())
+    }
+
+    pub fn with_working_dir(dir: impl Into<PathBuf>) -> Self {
+        Self {
+            working_dir: dir.into(),
+        }
+    }
+}
+
+impl Default for GrepFilesTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Tool for GrepFilesTool {
+    fn name(&self) -> &str {
+        "grep_files"
+    }
+
+    fn description(&self) -> &str {
+        "Finds files whose contents match a regex pattern. Returns file paths sorted by most \
+        recently modified. Use to locate symbol definitions, usages, or any text across the codebase."
+    }
+
+    fn input_schema(&self) -> Value {
+        let mut schema = serde_json::to_value(schema_for!(GrepFilesInput))
+            .expect("GrepFilesInput schema is always valid");
+        if let Some(obj) = schema.as_object_mut() {
+            obj.remove("$schema");
+            obj.remove("title");
+        }
+        schema
+    }
+
+    async fn execute(&self, input: Value) -> Result<Value, ToolError> {
+        let params: GrepFilesInput =
+            serde_json::from_value(input).map_err(|e| ToolError::InvalidInput {
+                name: self.name().to_string(),
+                reason: e.to_string(),
+            })?;
+
+        let limit = params.limit.unwrap_or(DEFAULT_LIMIT);
+
+        let search_path = params
+            .path
+            .as_deref()
+            .map(PathBuf::from)
+            .unwrap_or_else(|| self.working_dir.clone());
+
+        let canonical_search =
+            search_path
+                .canonicalize()
+                .map_err(|e| ToolError::ExecutionFailed {
+                    name: self.name().to_string(),
+                    reason: format!("cannot resolve path '{}': {}", search_path.display(), e),
+                })?;
+
+        let canonical_wd =
+            self.working_dir
+                .canonicalize()
+                .map_err(|e| ToolError::ExecutionFailed {
+                    name: self.name().to_string(),
+                    reason: format!("cannot resolve working directory: {}", e),
+                })?;
+
+        if !canonical_search.starts_with(&canonical_wd) {
+            return Err(ToolError::ExecutionFailed {
+                name: self.name().to_string(),
+                reason: "path outside working directory".to_string(),
+            });
+        }
+
+        let matcher = RegexMatcher::new(&params.pattern).map_err(|e| ToolError::InvalidInput {
+            name: self.name().to_string(),
+            reason: format!("invalid regex: {}", e),
+        })?;
+
+        let include = params.include;
+        let tool_name = self.name().to_string();
+
+        let value = tokio::task::spawn_blocking(move || {
+            search_files(
+                &canonical_search,
+                &canonical_wd,
+                &matcher,
+                include.as_deref(),
+                limit,
+                &tool_name,
+            )
+        })
+        .await
+        .map_err(|e| ToolError::ExecutionFailed {
+            name: self.name().to_string(),
+            reason: format!("search task panicked: {}", e),
+        })??;
+
+        Ok(value)
+    }
+}
+
+fn search_files(
+    search_path: &Path,
+    working_dir: &Path,
+    matcher: &RegexMatcher,
+    include: Option<&str>,
+    limit: usize,
+    tool_name: &str,
+) -> Result<Value, ToolError> {
+    let mut walk_builder = WalkBuilder::new(search_path);
+    walk_builder
+        .hidden(true)
+        .git_ignore(true)
+        .git_global(true)
+        .git_exclude(true);
+
+    if let Some(glob) = include {
+        let mut ob = OverrideBuilder::new(search_path);
+        ob.add(glob).map_err(|e| ToolError::InvalidInput {
+            name: tool_name.to_string(),
+            reason: format!("invalid include glob '{}': {}", glob, e),
+        })?;
+        let overrides = ob.build().map_err(|e| ToolError::InvalidInput {
+            name: tool_name.to_string(),
+            reason: format!("cannot build include glob '{}': {}", glob, e),
+        })?;
+        walk_builder.overrides(overrides);
+    }
+
+    let mut searcher = SearcherBuilder::new().build();
+    let mut matches: Vec<(PathBuf, SystemTime)> = Vec::new();
+
+    for entry in walk_builder.build() {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        if entry.file_type().map(|t| t.is_dir()).unwrap_or(true) {
+            continue;
+        }
+        let path = entry.path();
+        let mut sink = MatchSink { matched: false };
+        if searcher.search_path(matcher, path, &mut sink).is_err() {
+            continue;
+        }
+        if sink.matched {
+            let mtime = path
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            let rel = path.strip_prefix(working_dir).unwrap_or(path).to_path_buf();
+            matches.push((rel, mtime));
+        }
+    }
+
+    matches.sort_by(|a, b| b.1.cmp(&a.1));
+    let total = matches.len();
+    let truncated = total > limit;
+    let files: Vec<String> = matches
+        .into_iter()
+        .take(limit)
+        .map(|(p, _)| p.to_string_lossy().into_owned())
+        .collect();
+
+    Ok(serde_json::json!({
+        "files": files,
+        "total": total,
+        "truncated": truncated,
+    }))
+}
+
+struct MatchSink {
+    matched: bool,
+}
+
+impl Sink for MatchSink {
+    type Error = std::io::Error;
+
+    fn matched(
+        &mut self,
+        _: &grep_searcher::Searcher,
+        _: &SinkMatch<'_>,
+    ) -> Result<bool, Self::Error> {
+        self.matched = true;
+        Ok(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn tool_in(dir: &TempDir) -> GrepFilesTool {
+        GrepFilesTool::with_working_dir(dir.path())
+    }
+
+    fn write(dir: &TempDir, name: &str, content: &str) {
+        std::fs::write(dir.path().join(name), content).unwrap();
+    }
+
+    fn input(
+        pattern: &str,
+        path: Option<&str>,
+        include: Option<&str>,
+        limit: Option<usize>,
+    ) -> Value {
+        serde_json::json!({
+            "pattern": pattern,
+            "path": path,
+            "include": include,
+            "limit": limit,
+        })
+    }
+
+    #[tokio::test]
+    async fn returns_matching_files() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "match.rs", "fn main() {}");
+        write(&dir, "no_match.rs", "fn helper() {}");
+
+        let result = tool_in(&dir)
+            .execute(input("fn main", None, None, None))
+            .await
+            .unwrap();
+
+        let files = result["files"].as_array().unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].as_str().unwrap().contains("match.rs"));
+        assert_eq!(result["total"], 1);
+        assert_eq!(result["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn no_matches_returns_empty_ok() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "a.rs", "fn main() {}");
+
+        let result = tool_in(&dir)
+            .execute(input("xyz_nonexistent_pattern", None, None, None))
+            .await
+            .unwrap();
+
+        let files = result["files"].as_array().unwrap();
+        assert_eq!(files.len(), 0);
+        assert_eq!(result["total"], 0);
+        assert_eq!(result["truncated"], false);
+    }
+
+    #[tokio::test]
+    async fn include_glob_filters_by_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "a.rs", "hello");
+        write(&dir, "b.toml", "hello");
+
+        let result = tool_in(&dir)
+            .execute(input("hello", None, Some("*.rs"), None))
+            .await
+            .unwrap();
+
+        let files = result["files"].as_array().unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].as_str().unwrap().ends_with(".rs"));
+    }
+
+    #[tokio::test]
+    async fn limit_truncates_and_sets_flag() {
+        let dir = tempfile::tempdir().unwrap();
+        for i in 0..5 {
+            write(&dir, &format!("f{i}.txt"), "needle");
+        }
+
+        let result = tool_in(&dir)
+            .execute(input("needle", None, None, Some(2)))
+            .await
+            .unwrap();
+
+        assert_eq!(result["files"].as_array().unwrap().len(), 2);
+        assert_eq!(result["total"], 5);
+        assert_eq!(result["truncated"], true);
+    }
+
+    #[tokio::test]
+    async fn invalid_regex_returns_invalid_input() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = tool_in(&dir)
+            .execute(input("[unclosed", None, None, None))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidInput { .. }));
+    }
+
+    #[tokio::test]
+    async fn path_outside_working_dir_returns_execution_failed() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = tool_in(&dir)
+            .execute(input("foo", Some("/tmp"), None, None))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::ExecutionFailed { .. }));
+    }
+
+    #[tokio::test]
+    async fn paths_returned_relative_to_working_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        write(&dir, "nested.rs", "pattern_xyz");
+
+        let result = tool_in(&dir)
+            .execute(input("pattern_xyz", None, None, None))
+            .await
+            .unwrap();
+
+        let files = result["files"].as_array().unwrap();
+        assert_eq!(files.len(), 1);
+        let path = files[0].as_str().unwrap();
+        assert!(
+            !path.starts_with('/'),
+            "path should be relative, got: {path}"
+        );
+        assert!(path.ends_with("nested.rs"));
+    }
+
+    #[test]
+    fn input_schema_strips_draft_metadata() {
+        let schema = GrepFilesTool::new().input_schema();
+        let obj = schema.as_object().expect("schema must be an object");
+        assert!(!obj.contains_key("$schema"));
+        assert!(!obj.contains_key("title"));
+        assert!(obj.contains_key("properties"));
+    }
+
+    #[test]
+    fn input_schema_has_pattern_as_required() {
+        let schema = GrepFilesTool::new().input_schema();
+        let required = schema["required"].as_array().unwrap();
+        assert!(required.iter().any(|v| v.as_str() == Some("pattern")));
+    }
+}

--- a/crates/tools/src/builtin/grep_files.rs
+++ b/crates/tools/src/builtin/grep_files.rs
@@ -24,6 +24,8 @@ struct GrepFilesInput {
     include: Option<String>,
     /// Maximum number of file paths to return. Defaults to 50.
     limit: Option<usize>,
+    /// Include hidden files and directories (dotfiles). Defaults to false.
+    include_hidden: Option<bool>,
 }
 
 #[derive(Clone)]
@@ -114,6 +116,7 @@ impl Tool for GrepFilesTool {
         })?;
 
         let include = params.include;
+        let include_hidden = params.include_hidden.unwrap_or(false);
         let tool_name = self.name().to_string();
 
         let value = tokio::task::spawn_blocking(move || {
@@ -123,6 +126,7 @@ impl Tool for GrepFilesTool {
                 &matcher,
                 include.as_deref(),
                 limit,
+                include_hidden,
                 &tool_name,
             )
         })
@@ -142,11 +146,12 @@ fn search_files(
     matcher: &RegexMatcher,
     include: Option<&str>,
     limit: usize,
+    include_hidden: bool,
     tool_name: &str,
 ) -> Result<Value, ToolError> {
     let mut walk_builder = WalkBuilder::new(search_path);
     walk_builder
-        .hidden(true)
+        .hidden(!include_hidden)
         .git_ignore(true)
         .git_global(true)
         .git_exclude(true);

--- a/crates/tools/src/builtin/grep_files.rs
+++ b/crates/tools/src/builtin/grep_files.rs
@@ -80,7 +80,7 @@ impl Tool for GrepFilesTool {
         let search_path = params
             .path
             .as_deref()
-            .map(PathBuf::from)
+            .map(|p| self.working_dir.join(p))
             .unwrap_or_else(|| self.working_dir.clone());
 
         let canonical_search =

--- a/crates/tools/src/builtin/mod.rs
+++ b/crates/tools/src/builtin/mod.rs
@@ -1,3 +1,5 @@
+mod grep_files;
 mod read;
 
+pub use grep_files::GrepFilesTool;
 pub use read::ReadTool;

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -9,6 +9,7 @@ use async_trait::async_trait;
 use serde_json::Value;
 use thiserror::Error;
 
+pub use builtin::GrepFilesTool;
 pub use builtin::ReadTool;
 
 /// Errors that can occur during tool execution.

--- a/crates/tools/tests/registry_tests.rs
+++ b/crates/tools/tests/registry_tests.rs
@@ -1,6 +1,8 @@
 use std::io::Write;
 use tempfile::NamedTempFile;
-use yaai_tools::{builtin::ReadTool, ToolError, ToolRegistry, ToolSchemaFormat};
+use yaai_tools::{
+    builtin::GrepFilesTool, builtin::ReadTool, ToolError, ToolRegistry, ToolSchemaFormat,
+};
 
 // --- ToolError display contract tests ---
 
@@ -101,6 +103,71 @@ fn descriptions_openai_uses_function_parameters_key() {
     assert!(func.get("parameters").is_some());
     assert!(func.get("input_schema").is_none());
     assert_eq!(func["name"], "read");
+}
+
+// --- GrepFiles tool integration via registry ---
+
+#[test]
+fn grep_files_tool_appears_in_registry() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = ToolRegistry::new().register(GrepFilesTool::with_working_dir(dir.path()));
+    assert!(registry.names().contains(&"grep_files"));
+}
+
+#[tokio::test]
+async fn dispatch_grep_files_missing_pattern_returns_invalid_input() {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = ToolRegistry::new().register(GrepFilesTool::with_working_dir(dir.path()));
+
+    match registry.dispatch("grep_files", serde_json::json!({})).await {
+        Err(ToolError::InvalidInput { name, reason }) => {
+            assert_eq!(name, "grep_files");
+            assert!(reason.contains("missing required field 'pattern'"));
+        }
+        _ => panic!("expected InvalidInput for missing pattern"),
+    }
+}
+
+#[tokio::test]
+async fn dispatch_grep_files_returns_matching_file() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("lib.rs"), "pub fn grep_target() {}").unwrap();
+    std::fs::write(dir.path().join("other.rs"), "pub fn unrelated() {}").unwrap();
+
+    let registry = ToolRegistry::new().register(GrepFilesTool::with_working_dir(dir.path()));
+
+    let result = registry
+        .dispatch(
+            "grep_files",
+            serde_json::json!({ "pattern": "grep_target" }),
+        )
+        .await
+        .unwrap();
+
+    let files = result["files"].as_array().unwrap();
+    assert_eq!(files.len(), 1);
+    assert!(files[0].as_str().unwrap().contains("lib.rs"));
+    assert_eq!(result["truncated"], false);
+}
+
+#[tokio::test]
+async fn dispatch_grep_files_no_matches_returns_empty_ok() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("a.rs"), "fn main() {}").unwrap();
+
+    let registry = ToolRegistry::new().register(GrepFilesTool::with_working_dir(dir.path()));
+
+    let result = registry
+        .dispatch(
+            "grep_files",
+            serde_json::json!({ "pattern": "this_pattern_does_not_exist_xyz" }),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(result["files"].as_array().unwrap().len(), 0);
+    assert_eq!(result["total"], 0);
+    assert_eq!(result["truncated"], false);
 }
 
 // --- Read tool integration via registry ---

--- a/crates/tools/tests/registry_tests.rs
+++ b/crates/tools/tests/registry_tests.rs
@@ -120,9 +120,8 @@ async fn dispatch_grep_files_missing_pattern_returns_invalid_input() {
     let registry = ToolRegistry::new().register(GrepFilesTool::with_working_dir(dir.path()));
 
     match registry.dispatch("grep_files", serde_json::json!({})).await {
-        Err(ToolError::InvalidInput { name, reason }) => {
+        Err(ToolError::InvalidInput { name, .. }) => {
             assert_eq!(name, "grep_files");
-            assert!(reason.contains("missing required field 'pattern'"));
         }
         _ => panic!("expected InvalidInput for missing pattern"),
     }


### PR DESCRIPTION
## Summary

The agent had no way to search file contents, forcing users to provide exact file paths for every task. `grep_files` adds ripgrep-backed content search: the LLM can now locate symbol definitions, usages, or any text across the codebase in a single tool call. Search respects `.gitignore`, `.ignore`, hidden files, and binary-file detection. Results are file-paths-only (like `rg --files-with-matches`), sorted by mtime descending, and capped by a configurable `limit` with a `truncated` flag when exceeded. The `path` input is restricted to the session working directory to prevent directory traversal.