### PR TITLE
docs(tools/list_dir): explain truncation formula

### DIFF
--- a/crates/tools/src/builtin/list_dir.rs
+++ b/crates/tools/src/builtin/list_dir.rs
@@ -161,6 +161,7 @@ impl Tool for ListDirTool {
         let start = (offset - 1).min(total);
         let end = start.saturating_add(limit).min(total);
         let page = &all_entries[start..end];
+        // offset is 1-indexed; (offset-1)+limit is the exclusive 0-indexed end of this page
         let truncated = (offset - 1).saturating_add(limit) < total;
 
         let mut lines = vec![format!("{}/", canonical_target.display())];


### PR DESCRIPTION
## Summary

The truncation check `(offset-1)+limit < total` is correct but non-obvious because `offset` is 1-indexed. A short inline comment clarifies that `offset-1` converts to a 0-indexed start and the full expression is the exclusive end of the current page, making the comparison to `total` self-explanatory.

Closes #32