### PR TITLE
fix(tools): enforce working-dir bounds and deduplicate resolution logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -653,54 +653,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "grep"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308ae749734e28d749a86f33212c7b756748568ce332f970ac1d9cd8531f32e6"
-dependencies = [
- "grep-cli",
- "grep-matcher",
- "grep-printer",
- "grep-regex",
- "grep-searcher",
-]
-
-[[package]]
-name = "grep-cli"
-version = "0.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf32d263c5d5cc2a23ce587097f5ddafdb188492ba2e6fb638eaccdc22453631"
-dependencies = [
- "bstr",
- "globset",
- "libc",
- "log",
- "termcolor",
- "winapi-util",
-]
-
-[[package]]
 name = "grep-matcher"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36d7b71093325ab22d780b40d7df3066ae4aebb518ba719d38c697a8228a8023"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "grep-printer"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c112110ae4a891aa4d83ab82ecf734b307497d066f437686175e83fbd4e013fe"
-dependencies = [
- "bstr",
- "grep-matcher",
- "grep-searcher",
- "log",
- "serde",
- "serde_json",
- "termcolor",
 ]
 
 [[package]]
@@ -2098,15 +2056,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3199,7 +3148,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "grep",
  "grep-regex",
  "grep-searcher",
  "ignore",

--- a/crates/tools/src/builtin/grep_files.rs
+++ b/crates/tools/src/builtin/grep_files.rs
@@ -87,15 +87,8 @@ impl Tool for GrepFilesTool {
             .map(|p| self.working_dir.join(p))
             .unwrap_or_else(|| self.working_dir.clone());
 
-        let canonical_search =
+        let (canonical_search, canonical_wd) =
             super::path::resolve_and_check(&self.working_dir, &search_path, self.name()).await?;
-
-        let canonical_wd = tokio::fs::canonicalize(&self.working_dir)
-            .await
-            .map_err(|e| ToolError::ExecutionFailed {
-                name: self.name().to_string(),
-                reason: format!("cannot resolve working directory: {}", e),
-            })?;
 
         let matcher = RegexMatcher::new(&params.pattern).map_err(|e| ToolError::InvalidInput {
             name: self.name().to_string(),

--- a/crates/tools/src/builtin/grep_files.rs
+++ b/crates/tools/src/builtin/grep_files.rs
@@ -88,27 +88,14 @@ impl Tool for GrepFilesTool {
             .unwrap_or_else(|| self.working_dir.clone());
 
         let canonical_search =
-            search_path
-                .canonicalize()
-                .map_err(|e| ToolError::ExecutionFailed {
-                    name: self.name().to_string(),
-                    reason: format!("cannot resolve path '{}': {}", search_path.display(), e),
-                })?;
+            super::path::resolve_and_check(&self.working_dir, &search_path, self.name()).await?;
 
-        let canonical_wd =
-            self.working_dir
-                .canonicalize()
-                .map_err(|e| ToolError::ExecutionFailed {
-                    name: self.name().to_string(),
-                    reason: format!("cannot resolve working directory: {}", e),
-                })?;
-
-        if !canonical_search.starts_with(&canonical_wd) {
-            return Err(ToolError::ExecutionFailed {
+        let canonical_wd = tokio::fs::canonicalize(&self.working_dir)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed {
                 name: self.name().to_string(),
-                reason: "path outside working directory".to_string(),
-            });
-        }
+                reason: format!("cannot resolve working directory: {}", e),
+            })?;
 
         let matcher = RegexMatcher::new(&params.pattern).map_err(|e| ToolError::InvalidInput {
             name: self.name().to_string(),

--- a/crates/tools/src/builtin/list_dir.rs
+++ b/crates/tools/src/builtin/list_dir.rs
@@ -52,22 +52,6 @@ impl ListDirTool {
     pub fn new() -> Self {
         Self { working_dir: None }
     }
-
-    async fn resolve_working_dir(&self) -> Result<PathBuf, ToolError> {
-        let raw = match &self.working_dir {
-            Some(p) => p.clone(),
-            None => std::env::current_dir().map_err(|e| ToolError::ExecutionFailed {
-                name: self.name().to_string(),
-                reason: format!("cannot determine working directory: {e}"),
-            })?,
-        };
-        tokio::fs::canonicalize(&raw)
-            .await
-            .map_err(|e| ToolError::ExecutionFailed {
-                name: self.name().to_string(),
-                reason: format!("cannot canonicalize working directory: {e}"),
-            })
-    }
 }
 
 impl Default for ListDirTool {
@@ -126,21 +110,19 @@ impl Tool for ListDirTool {
             });
         }
 
-        let canonical_target = tokio::fs::canonicalize(&params.dir_path)
-            .await
-            .map_err(|e| ToolError::ExecutionFailed {
+        let working_dir = match &self.working_dir {
+            Some(p) => p.clone(),
+            None => std::env::current_dir().map_err(|e| ToolError::ExecutionFailed {
                 name: self.name().to_string(),
-                reason: format!("cannot access '{}': {e}", params.dir_path),
-            })?;
-
-        let canonical_cwd = self.resolve_working_dir().await?;
-
-        if !canonical_target.starts_with(&canonical_cwd) {
-            return Err(ToolError::ExecutionFailed {
-                name: self.name().to_string(),
-                reason: format!("'{}' is outside the working directory", params.dir_path),
-            });
-        }
+                reason: format!("cannot determine working directory: {e}"),
+            })?,
+        };
+        let canonical_target = super::path::resolve_and_check(
+            &working_dir,
+            std::path::Path::new(&params.dir_path),
+            self.name(),
+        )
+        .await?;
 
         let metadata = tokio::fs::metadata(&canonical_target).await.map_err(|e| {
             ToolError::ExecutionFailed {

--- a/crates/tools/src/builtin/list_dir.rs
+++ b/crates/tools/src/builtin/list_dir.rs
@@ -117,7 +117,7 @@ impl Tool for ListDirTool {
                 reason: format!("cannot determine working directory: {e}"),
             })?,
         };
-        let canonical_target = super::path::resolve_and_check(
+        let (canonical_target, _) = super::path::resolve_and_check(
             &working_dir,
             std::path::Path::new(&params.dir_path),
             self.name(),

--- a/crates/tools/src/builtin/mod.rs
+++ b/crates/tools/src/builtin/mod.rs
@@ -1,5 +1,6 @@
 mod grep_files;
 mod list_dir;
+mod path;
 mod read;
 
 pub use grep_files::GrepFilesTool;

--- a/crates/tools/src/builtin/path.rs
+++ b/crates/tools/src/builtin/path.rs
@@ -1,0 +1,88 @@
+use crate::ToolError;
+use std::path::{Path, PathBuf};
+
+/// Resolves `input_path` and `working_dir` to canonical paths, then verifies
+/// that `input_path` falls within `working_dir`. Returns the canonical input path.
+pub(super) async fn resolve_and_check(
+    working_dir: &Path,
+    input_path: &Path,
+    tool_name: &str,
+) -> Result<PathBuf, ToolError> {
+    let canonical_input =
+        tokio::fs::canonicalize(input_path)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed {
+                name: tool_name.to_string(),
+                reason: format!("cannot access '{}': {e}", input_path.display()),
+            })?;
+
+    let canonical_wd =
+        tokio::fs::canonicalize(working_dir)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed {
+                name: tool_name.to_string(),
+                reason: format!("cannot canonicalize working directory: {e}"),
+            })?;
+
+    if !canonical_input.starts_with(&canonical_wd) {
+        return Err(ToolError::ExecutionFailed {
+            name: tool_name.to_string(),
+            reason: format!(
+                "'{}' is outside the working directory",
+                input_path.display()
+            ),
+        });
+    }
+
+    Ok(canonical_input)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn allows_path_within_working_dir() {
+        let dir = tempdir().unwrap();
+        let file = dir.path().join("file.txt");
+        tokio::fs::write(&file, b"").await.unwrap();
+
+        let result = resolve_and_check(dir.path(), &file, "tool").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn allows_working_dir_itself() {
+        let dir = tempdir().unwrap();
+        let result = resolve_and_check(dir.path(), dir.path(), "tool").await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn rejects_path_outside_working_dir() {
+        let inside = tempdir().unwrap();
+        let outside = tempdir().unwrap();
+
+        let err = resolve_and_check(inside.path(), outside.path(), "tool")
+            .await
+            .unwrap_err();
+        match err {
+            ToolError::ExecutionFailed { reason, .. } => {
+                assert!(reason.contains("outside the working directory"));
+            }
+            _ => panic!("expected ExecutionFailed"),
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_nonexistent_path() {
+        let dir = tempdir().unwrap();
+        let missing = dir.path().join("does_not_exist.txt");
+
+        let err = resolve_and_check(dir.path(), &missing, "tool")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::ExecutionFailed { .. }));
+    }
+}

--- a/crates/tools/src/builtin/path.rs
+++ b/crates/tools/src/builtin/path.rs
@@ -2,12 +2,12 @@ use crate::ToolError;
 use std::path::{Path, PathBuf};
 
 /// Resolves `input_path` and `working_dir` to canonical paths, then verifies
-/// that `input_path` falls within `working_dir`. Returns the canonical input path.
+/// that `input_path` falls within `working_dir`. Returns `(canonical_input, canonical_wd)`.
 pub(super) async fn resolve_and_check(
     working_dir: &Path,
     input_path: &Path,
     tool_name: &str,
-) -> Result<PathBuf, ToolError> {
+) -> Result<(PathBuf, PathBuf), ToolError> {
     let canonical_input =
         tokio::fs::canonicalize(input_path)
             .await
@@ -34,7 +34,7 @@ pub(super) async fn resolve_and_check(
         });
     }
 
-    Ok(canonical_input)
+    Ok((canonical_input, canonical_wd))
 }
 
 #[cfg(test)]

--- a/crates/tools/src/builtin/read.rs
+++ b/crates/tools/src/builtin/read.rs
@@ -3,6 +3,7 @@ use async_trait::async_trait;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::path::PathBuf;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncSeekExt, BufReader};
 
 const DEFAULT_LIMIT: usize = 2000;
@@ -51,11 +52,19 @@ struct ReadResult<'a> {
 /// Binary files are rejected with a descriptive error.
 /// When output is truncated a `continuation` hint is included in the response.
 #[derive(Clone)]
-pub struct ReadTool;
+pub struct ReadTool {
+    working_dir: Option<PathBuf>,
+}
 
 impl ReadTool {
     pub fn new() -> Self {
-        Self
+        Self { working_dir: None }
+    }
+
+    pub fn with_working_dir(dir: impl Into<PathBuf>) -> Self {
+        Self {
+            working_dir: Some(dir.into()),
+        }
     }
 }
 
@@ -114,6 +123,16 @@ impl Tool for ReadTool {
                 reason: "limit must be >= 1".to_string(),
             });
         }
+
+        let working_dir = match &self.working_dir {
+            Some(p) => p.clone(),
+            None => std::env::current_dir().map_err(|e| ToolError::ExecutionFailed {
+                name: self.name().to_string(),
+                reason: format!("cannot determine working directory: {e}"),
+            })?,
+        };
+        super::path::resolve_and_check(&working_dir, std::path::Path::new(file_path), self.name())
+            .await?;
 
         // Stat the file
         let metadata =
@@ -269,11 +288,12 @@ mod tests {
 
     #[tokio::test]
     async fn reads_simple_file() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         writeln!(f, "hello").unwrap();
         writeln!(f, "world").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, None))
             .await
@@ -290,12 +310,13 @@ mod tests {
 
     #[tokio::test]
     async fn paginates_with_offset_and_limit() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         for i in 1..=10 {
             writeln!(f, "line {i}").unwrap();
         }
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), Some(4), Some(3)))
             .await
@@ -312,12 +333,13 @@ mod tests {
 
     #[tokio::test]
     async fn includes_continuation_when_truncated() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         for i in 1..=10 {
             writeln!(f, "line {i}").unwrap();
         }
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), Some(1), Some(3)))
             .await
@@ -331,10 +353,11 @@ mod tests {
 
     #[tokio::test]
     async fn no_continuation_when_fully_read() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         writeln!(f, "only line").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, None))
             .await
@@ -354,9 +377,34 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn errors_on_path_outside_working_directory() {
+        let inside = tempfile::tempdir().unwrap();
+        let outside = tempfile::tempdir().unwrap();
+        tokio::fs::write(outside.path().join("file.txt"), b"content")
+            .await
+            .unwrap();
+
+        let tool = ReadTool::with_working_dir(inside.path());
+        let result = tool
+            .execute(make_input(
+                outside.path().join("file.txt").to_str().unwrap(),
+                None,
+                None,
+            ))
+            .await;
+
+        match result {
+            Err(ToolError::ExecutionFailed { reason, .. }) => {
+                assert!(reason.contains("outside the working directory"));
+            }
+            _ => panic!("expected ExecutionFailed for path outside working directory"),
+        }
+    }
+
+    #[tokio::test]
     async fn errors_on_directory() {
         let dir = tempfile::tempdir().unwrap();
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(dir.path().to_str().unwrap(), None, None))
             .await;
@@ -371,10 +419,11 @@ mod tests {
 
     #[tokio::test]
     async fn errors_on_binary_file() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         f.write_all(&[0x00, 0x01, 0x02, 0xFF, 0xFE]).unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, None))
             .await;
@@ -389,10 +438,11 @@ mod tests {
 
     #[tokio::test]
     async fn errors_on_zero_limit() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         writeln!(f, "line").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, Some(0)))
             .await;
@@ -402,10 +452,11 @@ mod tests {
 
     #[tokio::test]
     async fn errors_on_zero_offset() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         writeln!(f, "line").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), Some(0), None))
             .await;
@@ -415,10 +466,11 @@ mod tests {
 
     #[tokio::test]
     async fn offset_past_eof_returns_empty_content() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         writeln!(f, "line 1").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), Some(999), None))
             .await
@@ -435,12 +487,13 @@ mod tests {
     #[tokio::test]
     async fn offset_past_eof_from_never_exceeds_to() {
         // Regression test: from must always be <= to regardless of offset value.
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         for i in 1..=5 {
             writeln!(f, "line {i}").unwrap();
         }
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         for out_of_range_offset in [6u64, 7, 100, 9999] {
             let result = tool
                 .execute(make_input(
@@ -464,11 +517,12 @@ mod tests {
     async fn long_line_returned_in_full_with_no_content_loss() {
         // A single line larger than MAX_BYTES must still be returned completely via the
         // fallback path — no silent truncation, no panic.
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         let big = "a".repeat(MAX_BYTES + 1024);
         writeln!(f, "{big}").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, None))
             .await
@@ -492,13 +546,14 @@ mod tests {
         // Line 1 alone exceeds MAX_BYTES. The fallback forces it into the response in full.
         // Lines 2 and 3 are then NOT included (the page is full after line 1).
         // A continuation hint must be present pointing at line 2.
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         let big = "b".repeat(MAX_BYTES + 1024);
         writeln!(f, "{big}").unwrap(); // line 1 — oversized
         writeln!(f, "line two").unwrap(); // line 2
         writeln!(f, "line three").unwrap(); // line 3
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, None))
             .await
@@ -538,11 +593,12 @@ mod tests {
 
     #[tokio::test]
     async fn unicode_content_is_returned_unmodified() {
-        let mut f = NamedTempFile::new().unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        let mut f = NamedTempFile::new_in(dir.path()).unwrap();
         writeln!(f, "héllo wörld 日本語").unwrap();
         writeln!(f, "second line").unwrap();
 
-        let tool = ReadTool::new();
+        let tool = ReadTool::with_working_dir(dir.path());
         let result = tool
             .execute(make_input(f.path().to_str().unwrap(), None, None))
             .await

--- a/crates/tools/src/builtin/read.rs
+++ b/crates/tools/src/builtin/read.rs
@@ -131,12 +131,16 @@ impl Tool for ReadTool {
                 reason: format!("cannot determine working directory: {e}"),
             })?,
         };
-        super::path::resolve_and_check(&working_dir, std::path::Path::new(file_path), self.name())
-            .await?;
+        let (canonical_path, _) = super::path::resolve_and_check(
+            &working_dir,
+            std::path::Path::new(file_path),
+            self.name(),
+        )
+        .await?;
 
         // Stat the file
         let metadata =
-            tokio::fs::metadata(file_path)
+            tokio::fs::metadata(&canonical_path)
                 .await
                 .map_err(|e| ToolError::ExecutionFailed {
                     name: self.name().to_string(),
@@ -151,13 +155,12 @@ impl Tool for ReadTool {
         }
 
         // Read raw bytes for binary detection
-        let mut file =
-            tokio::fs::File::open(file_path)
-                .await
-                .map_err(|e| ToolError::ExecutionFailed {
-                    name: self.name().to_string(),
-                    reason: format!("cannot open '{}': {}", file_path, e),
-                })?;
+        let mut file = tokio::fs::File::open(&canonical_path).await.map_err(|e| {
+            ToolError::ExecutionFailed {
+                name: self.name().to_string(),
+                reason: format!("cannot open '{}': {}", file_path, e),
+            }
+        })?;
 
         let sample_size = BINARY_SAMPLE_BYTES.min(metadata.len() as usize);
         let mut sample = vec![0u8; sample_size];

--- a/crates/tools/tests/registry_tests.rs
+++ b/crates/tools/tests/registry_tests.rs
@@ -173,11 +173,12 @@ async fn dispatch_grep_files_no_matches_returns_empty_ok() {
 
 #[tokio::test]
 async fn dispatch_read_returns_file_contents() {
-    let mut f = NamedTempFile::new().unwrap();
+    let dir = tempfile::tempdir().unwrap();
+    let mut f = NamedTempFile::new_in(dir.path()).unwrap();
     writeln!(f, "line one").unwrap();
     writeln!(f, "line two").unwrap();
 
-    let registry = ToolRegistry::new().register(ReadTool::new());
+    let registry = ToolRegistry::new().register(ReadTool::with_working_dir(dir.path()));
 
     let result = registry
         .dispatch(


### PR DESCRIPTION
## Summary

`ReadTool` accepted any absolute path with no working-directory check, letting the LLM call `read` with `/etc/passwd` or any other path on the system. This adds the same bounds enforcement that `list_dir` and `grep_files` already had.

The bounds-check logic was also copy-pasted across `list_dir` and `grep_files`. A single `resolve_and_check(working_dir, input_path, tool_name)` helper now owns the canonical-path resolution and `starts_with` containment check; all three tools delegate to it.

Closes #31