### PR TITLE
fix(llm): handle parallel tool calls for Anthropic and OpenAI

### DIFF
--- a/apps/cli/src/commands/tui/state.rs
+++ b/apps/cli/src/commands/tui/state.rs
@@ -109,17 +109,34 @@ impl AppState {
     }
 
     pub(crate) fn complete_run(&mut self, result: Result<PromptRunResult, String>) {
-        self.streaming.clear();
+        // Drain the streaming buffer before clearing it so we can commit the
+        // full accumulated text (all intermediate reasoning + final answer) as
+        // a permanent transcript entry instead of only the last answer.
+        let accumulated = std::mem::take(&mut self.streaming).raw;
         self.streaming_active = false;
         match result {
             Ok(result) => {
+                // Use accumulated streaming text when available — it contains all
+                // intermediate step reasoning plus the final answer.  Fall back to
+                // result.answer for non-streaming runs or when nothing was streamed.
+                let content = if accumulated.is_empty() {
+                    result.answer
+                } else {
+                    accumulated
+                };
                 self.transcript.push(TranscriptEntry {
                     role: TranscriptRole::Assistant,
-                    content: result.answer,
+                    content,
                 });
                 self.status = format!("Run complete in {} step(s).", result.steps_taken);
             }
             Err(err) => {
+                if !accumulated.is_empty() {
+                    self.transcript.push(TranscriptEntry {
+                        role: TranscriptRole::Assistant,
+                        content: accumulated,
+                    });
+                }
                 self.transcript.push(TranscriptEntry {
                     role: TranscriptRole::Error,
                     content: err,

--- a/apps/cli/src/commands/tui/state.rs
+++ b/apps/cli/src/commands/tui/state.rs
@@ -289,6 +289,21 @@ mod tests {
     }
 
     #[test]
+    fn complete_run_error_with_streamed_content_emits_both_entries() {
+        let mut state = AppState::default();
+        state.start_run("hello");
+        state.append_token("partial answer".to_string());
+        state.complete_run(Err("boom".to_string()));
+
+        assert_eq!(state.transcript.len(), 3); // user + assistant + error
+        assert_eq!(state.transcript[1].role, TranscriptRole::Assistant);
+        assert_eq!(state.transcript[1].content, "partial answer");
+        assert_eq!(state.transcript[2].role, TranscriptRole::Error);
+        assert_eq!(state.transcript[2].content, "boom");
+        assert_eq!(state.run_state, RunState::Idle);
+    }
+
+    #[test]
     fn escape_clears_ready_status() {
         let mut state = AppState {
             status: "custom".to_string(),

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{sse::pop_sse_line, ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
@@ -51,6 +51,13 @@ impl AnthropicClient {
 // ── Anthropic wire types ─────────────────────────────────────────────────────
 
 #[derive(Serialize)]
+struct ToolChoice {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    disable_parallel_tool_use: bool,
+}
+
+#[derive(Serialize)]
 struct MessagesRequest<'a> {
     model: &'a str,
     max_tokens: u32,
@@ -59,6 +66,8 @@ struct MessagesRequest<'a> {
     messages: Vec<AnthropicMessage>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     tools: &'a [Value],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
 }
@@ -114,12 +123,10 @@ enum ContentBlock {
 #[serde(tag = "type", rename_all = "snake_case")]
 enum StreamEvent {
     ContentBlockStart {
-        #[allow(dead_code)]
         index: usize,
         content_block: StreamBlock,
     },
     ContentBlockDelta {
-        #[allow(dead_code)]
         index: usize,
         delta: StreamDelta,
     },
@@ -261,12 +268,17 @@ impl LlmClient for AnthropicClient {
 
         let messages: Vec<AnthropicMessage> = turns.iter().map(turn_to_anthropic).collect();
 
+        let tool_choice = (!tools.is_empty()).then_some(ToolChoice {
+            kind: "auto",
+            disable_parallel_tool_use: true,
+        });
         let body = MessagesRequest {
             model: &self.model,
             max_tokens: DEFAULT_MAX_TOKENS,
             system,
             messages,
             tools,
+            tool_choice,
             stream: false,
         };
 
@@ -305,12 +317,17 @@ impl LlmClient for AnthropicClient {
 
         let messages: Vec<AnthropicMessage> = turns.iter().map(turn_to_anthropic).collect();
 
+        let tool_choice = (!tools.is_empty()).then_some(ToolChoice {
+            kind: "auto",
+            disable_parallel_tool_use: true,
+        });
         let body = MessagesRequest {
             model: &self.model,
             max_tokens: DEFAULT_MAX_TOKENS,
             system,
             messages,
             tools,
+            tool_choice,
             stream: true,
         };
 
@@ -335,6 +352,7 @@ impl LlmClient for AnthropicClient {
         let mut tool_id: Option<String> = None;
         let mut tool_name: Option<String> = None;
         let mut tool_json = String::new();
+        let mut tool_block_index: Option<usize> = None;
 
         while let Some(chunk) = response.chunk().await.context("reading SSE stream")? {
             buf.extend_from_slice(&chunk);
@@ -345,26 +363,37 @@ impl LlmClient for AnthropicClient {
                 };
 
                 match serde_json::from_str::<StreamEvent>(data) {
-                    Ok(StreamEvent::ContentBlockStart { content_block, .. }) => {
+                    Ok(StreamEvent::ContentBlockStart {
+                        index,
+                        content_block,
+                    }) => {
                         if let StreamBlock::ToolUse { id, name } = content_block {
-                            tool_id = Some(id);
-                            tool_name = Some(name);
+                            if tool_id.is_none() {
+                                tool_id = Some(id);
+                                tool_name = Some(name);
+                                tool_block_index = Some(index);
+                            }
                         }
                     }
-                    Ok(StreamEvent::ContentBlockDelta { delta, .. }) => match delta {
+                    Ok(StreamEvent::ContentBlockDelta { index, delta }) => match delta {
                         StreamDelta::TextDelta { text: t } => {
                             let _ = tx.send(t.clone());
                             text.push_str(&t);
                         }
                         StreamDelta::InputJsonDelta { partial_json } => {
-                            tool_json.push_str(&partial_json);
+                            if Some(index) == tool_block_index {
+                                tool_json.push_str(&partial_json);
+                            }
                         }
                         StreamDelta::Other => {}
                     },
                     Ok(StreamEvent::Error { error }) => {
                         bail!("Anthropic stream error: {}", error.message);
                     }
-                    Ok(StreamEvent::Other) | Err(_) => {}
+                    Ok(StreamEvent::Other) => {}
+                    Err(e) => {
+                        warn!(error = %e, raw = %data, "failed to parse SSE event");
+                    }
                 }
             }
         }
@@ -374,7 +403,8 @@ impl LlmClient for AnthropicClient {
                 let arguments = if tool_json.is_empty() {
                     serde_json::json!({})
                 } else {
-                    serde_json::from_str(&tool_json).context("parsing tool input JSON")?
+                    serde_json::from_str(&tool_json)
+                        .with_context(|| format!("parsing tool input JSON: {:?}", tool_json))?
                 };
                 Some(ToolCall {
                     id,
@@ -467,6 +497,7 @@ mod tests {
             system: None,
             messages: vec![],
             tools: &[],
+            tool_choice: None,
             stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
@@ -482,6 +513,7 @@ mod tests {
             system: None,
             messages: vec![],
             tools: &tools,
+            tool_choice: None,
             stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
@@ -594,5 +626,88 @@ mod tests {
         let r = parse_blocks(&blocks);
         assert!(r.content.is_none());
         assert!(r.tool_call.is_some());
+    }
+
+    // ── Streaming accumulation tests ─────────────────────────────────────────
+
+    /// Simulate the streaming loop over a set of SSE data lines and return the
+    /// accumulated tool call id, name, and raw json string.  The mpsc channel is
+    /// needed because `TextDelta` events send tokens to the UI.
+    fn run_sse_accumulation(sse_lines: &[&str]) -> (Option<String>, Option<String>, String) {
+        let (_tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let mut tool_id: Option<String> = None;
+        let mut tool_name: Option<String> = None;
+        let mut tool_json = String::new();
+        let mut tool_block_index: Option<usize> = None;
+
+        for line in sse_lines {
+            let Some(data) = line.strip_prefix("data: ") else {
+                continue;
+            };
+            let Ok(event) = serde_json::from_str::<StreamEvent>(data) else {
+                continue;
+            };
+            match event {
+                StreamEvent::ContentBlockStart {
+                    index,
+                    content_block: StreamBlock::ToolUse { id, name },
+                } => {
+                    if tool_id.is_none() {
+                        tool_id = Some(id);
+                        tool_name = Some(name);
+                        tool_block_index = Some(index);
+                    }
+                }
+                StreamEvent::ContentBlockStart { .. } => {}
+                StreamEvent::ContentBlockDelta { index, delta } => match delta {
+                    StreamDelta::TextDelta { .. } => {}
+                    StreamDelta::InputJsonDelta { partial_json } => {
+                        if Some(index) == tool_block_index {
+                            tool_json.push_str(&partial_json);
+                        }
+                    }
+                    StreamDelta::Other => {}
+                },
+                _ => {}
+            }
+        }
+        (tool_id, tool_name, tool_json)
+    }
+
+    #[test]
+    fn single_tool_call_accumulates_correctly() {
+        let lines = [
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"list_dir"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"dir_path\":"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"/\"}"}}"#,
+        ];
+        let (id, name, json) = run_sse_accumulation(&lines);
+        assert_eq!(id.as_deref(), Some("toolu_01"));
+        assert_eq!(name.as_deref(), Some("list_dir"));
+        let args: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(args["dir_path"], "/");
+    }
+
+    #[test]
+    fn parallel_tool_calls_captures_only_first() {
+        // Two sequential tool_use blocks in the same response (parallel tool use).
+        // Only the first should be captured; the second's JSON must NOT contaminate
+        // tool_json (which would produce invalid concatenated JSON).
+        let lines = [
+            r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"list_dir"}}"#,
+            r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"dir_path\":\"/\"}"}}"#,
+            r#"data: {"type":"content_block_stop","index":0}"#,
+            r#"data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_02","name":"read"}}"#,
+            r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"/README.md\"}"}}"#,
+            r#"data: {"type":"content_block_stop","index":1}"#,
+        ];
+        let (id, name, json) = run_sse_accumulation(&lines);
+        assert_eq!(id.as_deref(), Some("toolu_01"));
+        assert_eq!(name.as_deref(), Some("list_dir"));
+        // json must be valid and contain only the first tool's input
+        let args: serde_json::Value =
+            serde_json::from_str(&json).expect("tool_json must be valid JSON");
+        assert_eq!(args["dir_path"], "/");
+        assert!(args.get("file_path").is_none());
     }
 }

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -383,6 +383,8 @@ impl LlmClient for AnthropicClient {
                         StreamDelta::InputJsonDelta { partial_json } => {
                             if Some(index) == tool_block_index {
                                 tool_json.push_str(&partial_json);
+                            } else if tool_block_index.is_some() {
+                                warn!(skipped_index = index, "ignoring parallel tool call delta");
                             }
                         }
                         StreamDelta::Other => {}

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use tokio::sync::mpsc;
-use tracing::debug;
+use tracing::{debug, warn};
 
 use crate::{sse::pop_sse_line, ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
@@ -235,9 +235,18 @@ fn apply_stream_data(
                 if let Some(idx) = tool_call.index {
                     match accumulator.tool_block_index {
                         None => accumulator.tool_block_index = Some(idx),
-                        Some(first) if idx != first => continue,
+                        Some(first) if idx != first => {
+                            warn!(
+                                first_index = first,
+                                skipped_index = idx,
+                                "ignoring parallel tool call delta"
+                            );
+                            continue;
+                        }
                         _ => {}
                     }
+                } else if accumulator.tool_block_index.is_some() {
+                    // index absent but we already captured a call — treat as belonging to it
                 }
                 if let Some(id) = tool_call.id {
                     accumulator.tool_id = Some(id);

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -46,6 +46,8 @@ struct ChatRequest<'a> {
     messages: Vec<OaiMessage>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     tools: &'a [Value],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    parallel_tool_calls: Option<bool>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
 }
@@ -127,6 +129,7 @@ struct StreamDelta {
 
 #[derive(Deserialize)]
 struct OaiStreamToolCall {
+    index: Option<usize>,
     id: Option<String>,
     function: Option<OaiStreamFunction>,
 }
@@ -143,6 +146,7 @@ struct StreamAccumulator {
     tool_id: Option<String>,
     tool_name: Option<String>,
     tool_arguments: String,
+    tool_block_index: Option<usize>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -225,6 +229,16 @@ fn apply_stream_data(
 
         if let Some(tool_calls) = choice.delta.tool_calls {
             for tool_call in tool_calls {
+                // Track and filter by the first tool call's index so parallel
+                // tool calls don't contaminate tool_arguments with a second
+                // call's JSON, which would produce invalid concatenated JSON.
+                if let Some(idx) = tool_call.index {
+                    match accumulator.tool_block_index {
+                        None => accumulator.tool_block_index = Some(idx),
+                        Some(first) if idx != first => continue,
+                        _ => {}
+                    }
+                }
                 if let Some(id) = tool_call.id {
                     accumulator.tool_id = Some(id);
                 }
@@ -283,10 +297,12 @@ impl LlmClient for OpenAiClient {
         // OpenAI expects the system prompt as the first entry in the messages array.
         let messages = build_messages(system, turns);
 
+        let parallel_tool_calls = (!tools.is_empty()).then_some(false);
         let body = ChatRequest {
             model: &self.model,
             messages,
             tools,
+            parallel_tool_calls,
             stream: false,
         };
 
@@ -345,10 +361,12 @@ impl LlmClient for OpenAiClient {
         debug!(model = %self.model, turns = turns.len(), "calling OpenAI (streaming)");
 
         let messages = build_messages(system, turns);
+        let parallel_tool_calls = (!tools.is_empty()).then_some(false);
         let body = ChatRequest {
             model: &self.model,
             messages,
             tools,
+            parallel_tool_calls,
             stream: true,
         };
 
@@ -465,10 +483,15 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &[],
+            parallel_tool_calls: None,
             stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_none(), "empty tools must be omitted");
+        assert!(
+            json.get("parallel_tool_calls").is_none(),
+            "parallel_tool_calls must be omitted when None"
+        );
     }
 
     #[test]
@@ -478,10 +501,12 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &tools,
+            parallel_tool_calls: Some(false),
             stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_some());
+        assert_eq!(json["parallel_tool_calls"], false);
     }
 
     #[test]
@@ -490,6 +515,7 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &[],
+            parallel_tool_calls: None,
             stream: true,
         };
         let json = serde_json::to_value(&req).unwrap();
@@ -586,5 +612,48 @@ mod tests {
         let msg = turn_to_oai(&turn);
         assert!(msg.content.is_none());
         assert!(msg.tool_calls.is_some());
+    }
+
+    #[test]
+    fn parallel_tool_calls_in_stream_captures_only_first() {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut accumulator = StreamAccumulator::default();
+
+        // First tool call (index 0) — id and name arrive in separate deltas.
+        apply_stream_data(
+            r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_01","type":"function","function":{"name":"list_dir","arguments":""}}]}}]}"#,
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+        apply_stream_data(
+            r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"dir_path\":\"/\"}"}}]}}]}"#,
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+
+        // Second tool call (index 1) — must be ignored.
+        apply_stream_data(
+            r#"{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_02","type":"function","function":{"name":"read","arguments":""}}]}}]}"#,
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+        apply_stream_data(
+            r#"{"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"file_path\":\"/README.md\"}"}}]}}]}"#,
+            &tx,
+            &mut accumulator,
+        )
+        .unwrap();
+
+        let response = accumulated_response(accumulator).unwrap();
+        let tool_call = response.tool_call.unwrap();
+        assert_eq!(tool_call.id, "call_01");
+        assert_eq!(tool_call.name, "list_dir");
+        let args: serde_json::Value =
+            serde_json::from_str(&tool_call.arguments.to_string()).unwrap();
+        assert_eq!(args["dir_path"], "/");
+        assert!(args.get("file_path").is_none());
     }
 }


### PR DESCRIPTION
## Summary

Claude 4 and OpenAI models return multiple tool_use blocks in a single response by default. Both streaming accumulators concatenated JSON arguments from every block into one string, producing invalid JSON that broke tool call parsing and caused the agent to loop until `max_steps`. The fix tracks the first tool call's block index and discards deltas from subsequent blocks. `disable_parallel_tool_use: true` (Anthropic) and `parallel_tool_calls: false` (OpenAI) are also set on every request that includes tools so the model returns one call at a time and the conversation history stays consistent.

The TUI streaming buffer accumulated all reasoning tokens during a run, but `complete_run` was discarding the buffer and committing only `result.answer` to the transcript — losing all intermediate steps. Fixed by draining the buffer with `mem::take` and using its content as the permanent transcript entry.