### PR TITLE
feat(llm): support parallel tool calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -557,12 +557,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -570,6 +586,40 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -583,8 +633,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -3089,6 +3144,7 @@ name = "yaai-agent-loop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "futures",
  "serde",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ chrono = { version = "0.4", features = ["serde"] }
 # HTTP client (for LLM API calls)
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 
+# Async utilities
+futures = "0.3"
+
 # CLI
 clap = { version = "4.5", features = ["derive", "env", "wrap_help"] }
 crossterm = "0.28"

--- a/crates/agent-loop/Cargo.toml
+++ b/crates/agent-loop/Cargo.toml
@@ -14,6 +14,7 @@ anyhow = { workspace = true }
 tracing = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
+futures = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/agent-loop/src/lib.rs
+++ b/crates/agent-loop/src/lib.rs
@@ -4,12 +4,13 @@
 //! final answer or `max_steps` is reached.
 
 use anyhow::{bail, Result};
+use futures::future;
 use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tracing::{info, warn};
 use uuid::Uuid;
-use yaai_llm::{ConversationTurn, LlmClient, Message};
-use yaai_memory::{EntryContent, Role, SessionMemory};
+use yaai_llm::{ConversationTurn, LlmClient, Message, ToolCall};
+use yaai_memory::{EntryContent, MemoryToolCall, Role, SessionMemory};
 use yaai_tools::{ToolRegistry, ToolSchemaFormat};
 use yaai_tracer::{EventKind, Tracer};
 
@@ -116,17 +117,19 @@ impl<'a> AgentRunner<'a> {
                         role: e.role.to_string(),
                         content: text.clone(),
                     }),
-                    EntryContent::ToolCall {
-                        id,
-                        name,
-                        arguments,
-                        reasoning,
-                    } => ConversationTurn::AssistantToolCall {
-                        id: id.clone(),
-                        name: name.clone(),
-                        arguments: arguments.clone(),
-                        reasoning: reasoning.clone(),
-                    },
+                    EntryContent::ToolCall { calls, reasoning } => {
+                        ConversationTurn::AssistantToolCall {
+                            calls: calls
+                                .iter()
+                                .map(|c| ToolCall {
+                                    id: c.id.clone(),
+                                    name: c.name.clone(),
+                                    arguments: c.arguments.clone(),
+                                })
+                                .collect(),
+                            reasoning: reasoning.clone(),
+                        }
+                    }
                     EntryContent::ToolResult {
                         tool_call_id,
                         content,
@@ -162,7 +165,7 @@ impl<'a> AgentRunner<'a> {
                 }
             };
 
-            if response.content.is_none() && response.tool_call.is_none() {
+            if response.content.is_none() && response.tool_calls.is_empty() {
                 let msg = format!(
                     "agent '{}' received an empty LLM response at step {}",
                     self.config.id, step
@@ -187,59 +190,81 @@ impl<'a> AgentRunner<'a> {
                     .emit(&self.config.id, step, EventKind::Decision, text)?;
                 // Only store a standalone text entry when there is no tool call.
                 // When a tool call is present, the reasoning is stored inside it.
-                if response.tool_call.is_none() {
+                if response.tool_calls.is_empty() {
                     self.memory.add(Role::Assistant, text);
                 }
             }
 
-            if let Some(tc) = &response.tool_call {
-                info!(agent = %self.config.id, tool = %tc.name, step, "tool call");
+            if !response.tool_calls.is_empty() {
+                for tc in &response.tool_calls {
+                    info!(agent = %self.config.id, tool = %tc.name, step, "tool call");
+                    self.tracer.emit(
+                        &self.config.id,
+                        step,
+                        EventKind::ToolCall,
+                        serde_json::json!({ "tool": tc.name, "args": tc.arguments }),
+                    )?;
+                }
 
-                self.tracer.emit(
-                    &self.config.id,
-                    step,
-                    EventKind::ToolCall,
-                    serde_json::json!({ "tool": tc.name, "args": tc.arguments }),
-                )?;
-
-                // Store reasoning alongside the tool call so both are replayed as
-                // a single assistant message — required by Anthropic and OpenAI.
+                // Store reasoning alongside all tool calls so the batch is replayed
+                // as a single assistant message — required by Anthropic and OpenAI.
                 self.memory.add_entry(
                     Role::Assistant,
                     EntryContent::ToolCall {
-                        id: tc.id.clone(),
-                        name: tc.name.clone(),
-                        arguments: tc.arguments.clone(),
+                        calls: response
+                            .tool_calls
+                            .iter()
+                            .map(|tc| MemoryToolCall {
+                                id: tc.id.clone(),
+                                name: tc.name.clone(),
+                                arguments: tc.arguments.clone(),
+                            })
+                            .collect(),
                         reasoning: response.content.clone(),
                     },
                 );
 
-                let observation = match self.tools.dispatch(&tc.name, tc.arguments.clone()).await {
-                    Ok(result) => {
-                        self.tracer
-                            .emit(&self.config.id, step, EventKind::ToolResult, &result)?;
-                        result.to_string()
-                    }
-                    Err(e) => {
-                        let msg = format!("Tool error: {e}");
-                        self.tracer.emit(
-                            &self.config.id,
-                            step,
-                            EventKind::Error,
-                            serde_json::json!({ "error": &msg }),
-                        )?;
-                        warn!(agent = %self.config.id, error = %e, "tool execution failed");
-                        msg
-                    }
-                };
+                // Dispatch all tool calls concurrently.
+                let tools = self.tools;
+                let dispatch_futs: Vec<_> = response
+                    .tool_calls
+                    .iter()
+                    .map(|tc| {
+                        let name = tc.name.clone();
+                        let args = tc.arguments.clone();
+                        async move { tools.dispatch(&name, args).await }
+                    })
+                    .collect();
+                let dispatch_results = future::join_all(dispatch_futs).await;
 
-                self.memory.add_entry(
-                    Role::User,
-                    EntryContent::ToolResult {
-                        tool_call_id: tc.id.clone(),
-                        content: observation,
-                    },
-                );
+                for (tc, result) in response.tool_calls.iter().zip(dispatch_results) {
+                    let observation = match result {
+                        Ok(val) => {
+                            self.tracer
+                                .emit(&self.config.id, step, EventKind::ToolResult, &val)?;
+                            val.to_string()
+                        }
+                        Err(e) => {
+                            let msg = format!("Tool error: {e}");
+                            self.tracer.emit(
+                                &self.config.id,
+                                step,
+                                EventKind::Error,
+                                serde_json::json!({ "error": &msg }),
+                            )?;
+                            warn!(agent = %self.config.id, error = %e, "tool execution failed");
+                            msg
+                        }
+                    };
+
+                    self.memory.add_entry(
+                        Role::User,
+                        EntryContent::ToolResult {
+                            tool_call_id: tc.id.clone(),
+                            content: observation,
+                        },
+                    );
+                }
             } else if response.is_final_answer() {
                 let answer = response.content.unwrap_or_default();
                 info!(agent = %self.config.id, step, "final answer");

--- a/crates/agent-loop/tests/agent_loop_tests.rs
+++ b/crates/agent-loop/tests/agent_loop_tests.rs
@@ -166,7 +166,7 @@ async fn graceful_tool_error_continues_loop() {
 async fn empty_llm_response_returns_error() {
     let llm = StubClient::new(vec![LlmResponse {
         content: None,
-        tool_call: None,
+        tool_calls: vec![],
     }]);
     let tools = ToolRegistry::new();
     let (_tmp, tr) = tracer();
@@ -187,11 +187,11 @@ async fn reasoning_with_tool_call_stored_as_single_memory_entry() {
     let llm = StubClient::new(vec![
         LlmResponse {
             content: Some("I should read the file first.".to_string()),
-            tool_call: Some(ToolCall {
+            tool_calls: vec![ToolCall {
                 id: "call_1".to_string(),
                 name: "read".to_string(),
                 arguments: serde_json::json!({"file_path": path}),
-            }),
+            }],
         },
         LlmResponse::text("Done."),
     ]);
@@ -239,7 +239,7 @@ async fn tool_call_without_reasoning_stores_no_reasoning() {
 #[tokio::test]
 async fn standalone_text_response_stored_as_text_memory_entry() {
     // Regression: response.content = Some(...) with no tool call must create a
-    // standalone Text entry in memory. The `if response.tool_call.is_none()`
+    // standalone Text entry in memory. The `if response.tool_calls.is_empty()`
     // guard in the agent loop is the only thing keeping this path working.
     let llm = StubClient::new(vec![LlmResponse::text("Just a text answer.")]);
     let tools = ToolRegistry::new();
@@ -254,6 +254,52 @@ async fn standalone_text_response_stored_as_text_memory_entry() {
     assert_eq!(result.memory.len(), 2);
     let entry = &result.memory.entries()[1];
     assert!(matches!(&entry.content, EntryContent::Text { text } if text == "Just a text answer."));
+    tr.close().await.unwrap();
+}
+
+#[tokio::test]
+async fn parallel_tool_calls_dispatched_and_stored() {
+    let (_f1, path1) = temp_file_path();
+    let (_f2, path2) = temp_file_path();
+    let llm = StubClient::new(vec![
+        LlmResponse {
+            content: None,
+            tool_calls: vec![
+                ToolCall {
+                    id: "call_1".to_string(),
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"file_path": path1}),
+                },
+                ToolCall {
+                    id: "call_2".to_string(),
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"file_path": path2}),
+                },
+            ],
+        },
+        LlmResponse::text("Both files read."),
+    ]);
+    let tools = ToolRegistry::new().register(ReadTool::new());
+    let (_tmp, tr) = tracer();
+
+    let result = AgentRunner::new(&cfg(5), &llm, &tools, &tr, ToolSchemaFormat::OpenAi)
+        .run("read two files")
+        .await
+        .unwrap();
+
+    assert_eq!(result.answer, "Both files read.");
+    assert_eq!(result.steps_taken, 2);
+
+    // user task + one ToolCall batch entry + two ToolResult entries + final answer = 5
+    assert_eq!(result.memory.len(), 5);
+
+    // The single batch entry carries both calls.
+    let batch_entry = &result.memory.entries()[1];
+    assert!(matches!(
+        &batch_entry.content,
+        EntryContent::ToolCall { calls, .. } if calls.len() == 2
+    ));
+
     tr.close().await.unwrap();
 }
 

--- a/crates/llm/src/anthropic.rs
+++ b/crates/llm/src/anthropic.rs
@@ -4,6 +4,7 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use tokio::sync::mpsc;
 use tracing::{debug, warn};
 
@@ -54,7 +55,6 @@ impl AnthropicClient {
 struct ToolChoice {
     #[serde(rename = "type")]
     kind: &'static str,
-    disable_parallel_tool_use: bool,
 }
 
 #[derive(Serialize)]
@@ -184,21 +184,18 @@ fn turn_to_anthropic(turn: &ConversationTurn) -> AnthropicMessage {
                 text: content.clone(),
             }],
         },
-        ConversationTurn::AssistantToolCall {
-            id,
-            name,
-            arguments,
-            reasoning,
-        } => {
+        ConversationTurn::AssistantToolCall { calls, reasoning } => {
             let mut blocks = Vec::new();
             if let Some(text) = reasoning {
                 blocks.push(AnthropicBlock::Text { text: text.clone() });
             }
-            blocks.push(AnthropicBlock::ToolUse {
-                id: id.clone(),
-                name: name.clone(),
-                input: arguments.clone(),
-            });
+            for tc in calls {
+                blocks.push(AnthropicBlock::ToolUse {
+                    id: tc.id.clone(),
+                    name: tc.name.clone(),
+                    input: tc.arguments.clone(),
+                });
+            }
             AnthropicMessage {
                 role: "assistant",
                 content: blocks,
@@ -217,42 +214,83 @@ fn turn_to_anthropic(turn: &ConversationTurn) -> AnthropicMessage {
     }
 }
 
+/// Build the messages array for an Anthropic request, merging consecutive
+/// ToolResult turns into a single user message — required by the API when
+/// parallel tool calls produce multiple results.
+fn build_anthropic_messages(turns: &[ConversationTurn]) -> Vec<AnthropicMessage> {
+    let mut messages = Vec::with_capacity(turns.len());
+    let mut i = 0;
+    while i < turns.len() {
+        if let ConversationTurn::ToolResult {
+            tool_call_id,
+            content,
+        } = &turns[i]
+        {
+            let mut blocks = vec![AnthropicBlock::ToolResult {
+                tool_use_id: tool_call_id.clone(),
+                content: content.clone(),
+            }];
+            i += 1;
+            while i < turns.len() {
+                if let ConversationTurn::ToolResult {
+                    tool_call_id,
+                    content,
+                } = &turns[i]
+                {
+                    blocks.push(AnthropicBlock::ToolResult {
+                        tool_use_id: tool_call_id.clone(),
+                        content: content.clone(),
+                    });
+                    i += 1;
+                } else {
+                    break;
+                }
+            }
+            messages.push(AnthropicMessage {
+                role: "user",
+                content: blocks,
+            });
+        } else {
+            messages.push(turn_to_anthropic(&turns[i]));
+            i += 1;
+        }
+    }
+    messages
+}
+
 /// Parse a slice of [`ContentBlock`]s into an [`LlmResponse`].
 ///
-/// Text blocks are concatenated (newline-separated) so that multiple `Text`
-/// blocks before a `ToolUse` are all preserved as reasoning. The first
-/// `ToolUse` block terminates the scan and the accumulated text is returned
-/// as `content` alongside the tool call.
+/// Text blocks before any tool call are accumulated as reasoning. All
+/// `ToolUse` blocks are collected (supporting parallel tool use).
 fn parse_blocks(blocks: &[ContentBlock]) -> LlmResponse {
     let mut reasoning: Option<String> = None;
+    let mut tool_calls: Vec<ToolCall> = Vec::new();
     for block in blocks {
         match block {
-            ContentBlock::Text { text } => match reasoning.as_mut() {
-                Some(r) => {
-                    r.push('\n');
-                    r.push_str(text);
+            ContentBlock::Text { text } => {
+                if tool_calls.is_empty() {
+                    match reasoning.as_mut() {
+                        Some(r) => {
+                            r.push('\n');
+                            r.push_str(text);
+                        }
+                        None => reasoning = Some(text.clone()),
+                    }
                 }
-                None => reasoning = Some(text.clone()),
-            },
+            }
             ContentBlock::ToolUse { id, name, input } => {
-                return LlmResponse {
-                    content: reasoning,
-                    tool_call: Some(ToolCall {
-                        id: id.clone(),
-                        name: name.clone(),
-                        arguments: input.clone(),
-                    }),
-                };
+                tool_calls.push(ToolCall {
+                    id: id.clone(),
+                    name: name.clone(),
+                    arguments: input.clone(),
+                });
             }
             ContentBlock::Unknown => {}
         }
     }
-    if let Some(text) = reasoning {
-        return LlmResponse::text(text);
-    }
     LlmResponse {
-        content: None,
-        tool_call: None,
+        content: reasoning,
+        tool_calls,
     }
 }
 
@@ -266,12 +304,9 @@ impl LlmClient for AnthropicClient {
     ) -> Result<LlmResponse> {
         debug!(model = %self.model, turns = turns.len(), "calling Anthropic");
 
-        let messages: Vec<AnthropicMessage> = turns.iter().map(turn_to_anthropic).collect();
+        let messages = build_anthropic_messages(turns);
 
-        let tool_choice = (!tools.is_empty()).then_some(ToolChoice {
-            kind: "auto",
-            disable_parallel_tool_use: true,
-        });
+        let tool_choice = (!tools.is_empty()).then_some(ToolChoice { kind: "auto" });
         let body = MessagesRequest {
             model: &self.model,
             max_tokens: DEFAULT_MAX_TOKENS,
@@ -315,12 +350,9 @@ impl LlmClient for AnthropicClient {
     ) -> Result<LlmResponse> {
         debug!(model = %self.model, turns = turns.len(), "calling Anthropic (streaming)");
 
-        let messages: Vec<AnthropicMessage> = turns.iter().map(turn_to_anthropic).collect();
+        let messages = build_anthropic_messages(turns);
 
-        let tool_choice = (!tools.is_empty()).then_some(ToolChoice {
-            kind: "auto",
-            disable_parallel_tool_use: true,
-        });
+        let tool_choice = (!tools.is_empty()).then_some(ToolChoice { kind: "auto" });
         let body = MessagesRequest {
             model: &self.model,
             max_tokens: DEFAULT_MAX_TOKENS,
@@ -349,10 +381,8 @@ impl LlmClient for AnthropicClient {
 
         let mut buf = Vec::new();
         let mut text = String::new();
-        let mut tool_id: Option<String> = None;
-        let mut tool_name: Option<String> = None;
-        let mut tool_json = String::new();
-        let mut tool_block_index: Option<usize> = None;
+        // key: block index, value: (id, name, accumulated_json)
+        let mut tool_blocks: BTreeMap<usize, (String, String, String)> = BTreeMap::new();
 
         while let Some(chunk) = response.chunk().await.context("reading SSE stream")? {
             buf.extend_from_slice(&chunk);
@@ -368,11 +398,9 @@ impl LlmClient for AnthropicClient {
                         content_block,
                     }) => {
                         if let StreamBlock::ToolUse { id, name } = content_block {
-                            if tool_id.is_none() {
-                                tool_id = Some(id);
-                                tool_name = Some(name);
-                                tool_block_index = Some(index);
-                            }
+                            tool_blocks
+                                .entry(index)
+                                .or_insert((id, name, String::new()));
                         }
                     }
                     Ok(StreamEvent::ContentBlockDelta { index, delta }) => match delta {
@@ -381,10 +409,8 @@ impl LlmClient for AnthropicClient {
                             text.push_str(&t);
                         }
                         StreamDelta::InputJsonDelta { partial_json } => {
-                            if Some(index) == tool_block_index {
-                                tool_json.push_str(&partial_json);
-                            } else if tool_block_index.is_some() {
-                                warn!(skipped_index = index, "ignoring parallel tool call delta");
+                            if let Some(entry) = tool_blocks.get_mut(&index) {
+                                entry.2.push_str(&partial_json);
                             }
                         }
                         StreamDelta::Other => {}
@@ -400,26 +426,29 @@ impl LlmClient for AnthropicClient {
             }
         }
 
-        let tool_call = match (tool_id, tool_name) {
-            (Some(id), Some(name)) => {
-                let arguments = if tool_json.is_empty() {
+        let tool_calls = tool_blocks
+            .into_values()
+            .map(|(id, name, json)| -> Result<ToolCall> {
+                let arguments = if json.is_empty() {
                     serde_json::json!({})
                 } else {
-                    serde_json::from_str(&tool_json)
-                        .with_context(|| format!("parsing tool input JSON: {:?}", tool_json))?
+                    serde_json::from_str(&json)
+                        .with_context(|| format!("parsing tool input JSON: {:?}", json))?
                 };
-                Some(ToolCall {
+                Ok(ToolCall {
                     id,
                     name,
                     arguments,
                 })
-            }
-            _ => None,
-        };
+            })
+            .collect::<Result<Vec<_>>>()?;
 
         let content = if text.is_empty() { None } else { Some(text) };
 
-        Ok(LlmResponse { content, tool_call })
+        Ok(LlmResponse {
+            content,
+            tool_calls,
+        })
     }
 }
 
@@ -463,9 +492,11 @@ mod tests {
     #[test]
     fn assistant_tool_call_maps_to_tool_use_block() {
         let turn = ConversationTurn::AssistantToolCall {
-            id: "toolu_01".to_string(),
-            name: "read".to_string(),
-            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            calls: vec![ToolCall {
+                id: "toolu_01".to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            }],
             reasoning: None,
         };
         let msg = turn_to_anthropic(&turn);
@@ -475,6 +506,34 @@ mod tests {
         assert_eq!(json["id"], "toolu_01");
         assert_eq!(json["name"], "read");
         assert_eq!(json["input"]["file_path"], "/tmp/a.txt");
+    }
+
+    #[test]
+    fn assistant_parallel_tool_calls_map_to_multiple_tool_use_blocks() {
+        let turn = ConversationTurn::AssistantToolCall {
+            calls: vec![
+                ToolCall {
+                    id: "toolu_01".to_string(),
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+                },
+                ToolCall {
+                    id: "toolu_02".to_string(),
+                    name: "list_dir".to_string(),
+                    arguments: serde_json::json!({"dir_path": "/tmp"}),
+                },
+            ],
+            reasoning: None,
+        };
+        let msg = turn_to_anthropic(&turn);
+        assert_eq!(msg.role, "assistant");
+        assert_eq!(msg.content.len(), 2);
+        let j0 = serde_json::to_value(&msg.content[0]).unwrap();
+        assert_eq!(j0["type"], "tool_use");
+        assert_eq!(j0["id"], "toolu_01");
+        let j1 = serde_json::to_value(&msg.content[1]).unwrap();
+        assert_eq!(j1["type"], "tool_use");
+        assert_eq!(j1["id"], "toolu_02");
     }
 
     #[test]
@@ -489,6 +548,50 @@ mod tests {
         assert_eq!(json["type"], "tool_result");
         assert_eq!(json["tool_use_id"], "toolu_01");
         assert_eq!(json["content"], "file contents here");
+    }
+
+    #[test]
+    fn consecutive_tool_results_merged_into_single_user_message() {
+        let turns = vec![
+            ConversationTurn::ToolResult {
+                tool_call_id: "toolu_01".to_string(),
+                content: "result one".to_string(),
+            },
+            ConversationTurn::ToolResult {
+                tool_call_id: "toolu_02".to_string(),
+                content: "result two".to_string(),
+            },
+        ];
+        let messages = build_anthropic_messages(&turns);
+        assert_eq!(
+            messages.len(),
+            1,
+            "consecutive ToolResult turns must merge into one message"
+        );
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content.len(), 2);
+        let j0 = serde_json::to_value(&messages[0].content[0]).unwrap();
+        assert_eq!(j0["tool_use_id"], "toolu_01");
+        let j1 = serde_json::to_value(&messages[0].content[1]).unwrap();
+        assert_eq!(j1["tool_use_id"], "toolu_02");
+    }
+
+    #[test]
+    fn non_consecutive_tool_results_stay_separate() {
+        // Results from different batches (separated by an assistant turn) must not merge.
+        let turns = vec![
+            ConversationTurn::ToolResult {
+                tool_call_id: "toolu_01".to_string(),
+                content: "r1".to_string(),
+            },
+            text_turn("assistant", "ok"),
+            ConversationTurn::ToolResult {
+                tool_call_id: "toolu_02".to_string(),
+                content: "r2".to_string(),
+            },
+        ];
+        let messages = build_anthropic_messages(&turns);
+        assert_eq!(messages.len(), 3);
     }
 
     #[test]
@@ -525,9 +628,11 @@ mod tests {
     #[test]
     fn tool_call_with_reasoning_emits_text_then_tool_use_blocks() {
         let turn = ConversationTurn::AssistantToolCall {
-            id: "toolu_01".to_string(),
-            name: "read".to_string(),
-            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            calls: vec![ToolCall {
+                id: "toolu_01".to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            }],
             reasoning: Some("I should read the file first.".to_string()),
         };
         let msg = turn_to_anthropic(&turn);
@@ -555,7 +660,8 @@ mod tests {
         ];
         let r = parse_blocks(&blocks);
         assert_eq!(r.content.as_deref(), Some("Let me check that file."));
-        let tc = r.tool_call.unwrap();
+        assert_eq!(r.tool_calls.len(), 1);
+        let tc = r.tool_calls.into_iter().next().unwrap();
         assert_eq!(tc.id, "toolu_01");
         assert_eq!(tc.name, "read");
     }
@@ -569,7 +675,7 @@ mod tests {
         }];
         let r = parse_blocks(&blocks);
         assert!(r.content.is_none());
-        assert!(r.tool_call.is_some());
+        assert!(!r.tool_calls.is_empty());
     }
 
     #[test]
@@ -592,14 +698,38 @@ mod tests {
             r.content.as_deref(),
             Some("First thought.\nSecond thought.")
         );
-        assert!(r.tool_call.is_some());
+        assert!(!r.tool_calls.is_empty());
+    }
+
+    #[test]
+    fn parallel_tool_use_blocks_all_captured() {
+        let blocks = vec![
+            ContentBlock::Text {
+                text: "Let me do both.".to_string(),
+            },
+            ContentBlock::ToolUse {
+                id: "toolu_01".to_string(),
+                name: "read".to_string(),
+                input: serde_json::json!({"file_path": "/a"}),
+            },
+            ContentBlock::ToolUse {
+                id: "toolu_02".to_string(),
+                name: "list_dir".to_string(),
+                input: serde_json::json!({"dir_path": "/"}),
+            },
+        ];
+        let r = parse_blocks(&blocks);
+        assert_eq!(r.content.as_deref(), Some("Let me do both."));
+        assert_eq!(r.tool_calls.len(), 2);
+        assert_eq!(r.tool_calls[0].id, "toolu_01");
+        assert_eq!(r.tool_calls[1].id, "toolu_02");
     }
 
     #[test]
     fn unknown_block_alone_returns_empty_response() {
         let r = parse_blocks(&[ContentBlock::Unknown]);
         assert!(r.content.is_none());
-        assert!(r.tool_call.is_none());
+        assert!(r.tool_calls.is_empty());
     }
 
     #[test]
@@ -612,7 +742,7 @@ mod tests {
         ];
         let r = parse_blocks(&blocks);
         assert_eq!(r.content.as_deref(), Some("thought"));
-        assert!(r.tool_call.is_none());
+        assert!(r.tool_calls.is_empty());
     }
 
     #[test]
@@ -627,20 +757,16 @@ mod tests {
         ];
         let r = parse_blocks(&blocks);
         assert!(r.content.is_none());
-        assert!(r.tool_call.is_some());
+        assert!(!r.tool_calls.is_empty());
     }
 
     // ── Streaming accumulation tests ─────────────────────────────────────────
 
-    /// Simulate the streaming loop over a set of SSE data lines and return the
-    /// accumulated tool call id, name, and raw json string.  The mpsc channel is
-    /// needed because `TextDelta` events send tokens to the UI.
-    fn run_sse_accumulation(sse_lines: &[&str]) -> (Option<String>, Option<String>, String) {
+    /// Simulate the streaming loop and return all accumulated tool calls as
+    /// `Vec<(id, name, raw_json)>` in block-index order.
+    fn run_sse_accumulation(sse_lines: &[&str]) -> Vec<(String, String, String)> {
         let (_tx, _rx) = tokio::sync::mpsc::unbounded_channel::<String>();
-        let mut tool_id: Option<String> = None;
-        let mut tool_name: Option<String> = None;
-        let mut tool_json = String::new();
-        let mut tool_block_index: Option<usize> = None;
+        let mut tool_blocks: BTreeMap<usize, (String, String, String)> = BTreeMap::new();
 
         for line in sse_lines {
             let Some(data) = line.strip_prefix("data: ") else {
@@ -654,26 +780,23 @@ mod tests {
                     index,
                     content_block: StreamBlock::ToolUse { id, name },
                 } => {
-                    if tool_id.is_none() {
-                        tool_id = Some(id);
-                        tool_name = Some(name);
-                        tool_block_index = Some(index);
-                    }
+                    tool_blocks
+                        .entry(index)
+                        .or_insert((id, name, String::new()));
                 }
                 StreamEvent::ContentBlockStart { .. } => {}
-                StreamEvent::ContentBlockDelta { index, delta } => match delta {
-                    StreamDelta::TextDelta { .. } => {}
-                    StreamDelta::InputJsonDelta { partial_json } => {
-                        if Some(index) == tool_block_index {
-                            tool_json.push_str(&partial_json);
-                        }
+                StreamEvent::ContentBlockDelta {
+                    index,
+                    delta: StreamDelta::InputJsonDelta { partial_json },
+                } => {
+                    if let Some(entry) = tool_blocks.get_mut(&index) {
+                        entry.2.push_str(&partial_json);
                     }
-                    StreamDelta::Other => {}
-                },
+                }
                 _ => {}
             }
         }
-        (tool_id, tool_name, tool_json)
+        tool_blocks.into_values().collect()
     }
 
     #[test]
@@ -683,18 +806,16 @@ mod tests {
             r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"dir_path\":"}}"#,
             r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"\"/\"}"}}"#,
         ];
-        let (id, name, json) = run_sse_accumulation(&lines);
-        assert_eq!(id.as_deref(), Some("toolu_01"));
-        assert_eq!(name.as_deref(), Some("list_dir"));
-        let args: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let calls = run_sse_accumulation(&lines);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, "toolu_01");
+        assert_eq!(calls[0].1, "list_dir");
+        let args: serde_json::Value = serde_json::from_str(&calls[0].2).unwrap();
         assert_eq!(args["dir_path"], "/");
     }
 
     #[test]
-    fn parallel_tool_calls_captures_only_first() {
-        // Two sequential tool_use blocks in the same response (parallel tool use).
-        // Only the first should be captured; the second's JSON must NOT contaminate
-        // tool_json (which would produce invalid concatenated JSON).
+    fn parallel_tool_calls_in_stream_captured_correctly() {
         let lines = [
             r#"data: {"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"toolu_01","name":"list_dir"}}"#,
             r#"data: {"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"dir_path\":\"/\"}"}}"#,
@@ -703,13 +824,17 @@ mod tests {
             r#"data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"/README.md\"}"}}"#,
             r#"data: {"type":"content_block_stop","index":1}"#,
         ];
-        let (id, name, json) = run_sse_accumulation(&lines);
-        assert_eq!(id.as_deref(), Some("toolu_01"));
-        assert_eq!(name.as_deref(), Some("list_dir"));
-        // json must be valid and contain only the first tool's input
-        let args: serde_json::Value =
-            serde_json::from_str(&json).expect("tool_json must be valid JSON");
-        assert_eq!(args["dir_path"], "/");
-        assert!(args.get("file_path").is_none());
+        let calls = run_sse_accumulation(&lines);
+        assert_eq!(calls.len(), 2);
+        // first call
+        assert_eq!(calls[0].0, "toolu_01");
+        assert_eq!(calls[0].1, "list_dir");
+        let args0: serde_json::Value = serde_json::from_str(&calls[0].2).unwrap();
+        assert_eq!(args0["dir_path"], "/");
+        // second call
+        assert_eq!(calls[1].0, "toolu_02");
+        assert_eq!(calls[1].1, "read");
+        let args1: serde_json::Value = serde_json::from_str(&calls[1].2).unwrap();
+        assert_eq!(args1["file_path"], "/README.md");
     }
 }

--- a/crates/llm/src/lib.rs
+++ b/crates/llm/src/lib.rs
@@ -68,11 +68,9 @@ impl Message {
 pub enum ConversationTurn {
     Text(Message),
     AssistantToolCall {
-        /// Provider-issued call ID used to correlate result messages.
-        id: String,
-        name: String,
-        arguments: Value,
-        /// Text the model emitted before choosing this tool call (chain-of-thought).
+        /// One or more tool calls emitted in this turn (parallel tool use).
+        calls: Vec<ToolCall>,
+        /// Text the model emitted before the tool calls (chain-of-thought).
         reasoning: Option<String>,
     },
     ToolResult {
@@ -95,32 +93,32 @@ pub struct ToolCall {
 pub struct LlmResponse {
     /// Free-text content (reasoning, final answer, etc.).
     pub content: Option<String>,
-    /// Tool call, if the LLM chose to invoke a tool this step.
-    pub tool_call: Option<ToolCall>,
+    /// Tool calls emitted this step — empty when the model returned a final answer.
+    pub tool_calls: Vec<ToolCall>,
 }
 
 impl LlmResponse {
     pub fn text(content: impl Into<String>) -> Self {
         Self {
             content: Some(content.into()),
-            tool_call: None,
+            tool_calls: vec![],
         }
     }
 
     pub fn tool(id: impl Into<String>, name: impl Into<String>, arguments: Value) -> Self {
         Self {
             content: None,
-            tool_call: Some(ToolCall {
+            tool_calls: vec![ToolCall {
                 id: id.into(),
                 name: name.into(),
                 arguments,
-            }),
+            }],
         }
     }
 
-    /// True when the response contains text and no tool call — signals loop end.
+    /// True when the response contains text and no tool calls — signals loop end.
     pub fn is_final_answer(&self) -> bool {
-        self.tool_call.is_none() && self.content.is_some()
+        self.tool_calls.is_empty() && self.content.is_some()
     }
 }
 

--- a/crates/llm/src/openai.rs
+++ b/crates/llm/src/openai.rs
@@ -4,8 +4,9 @@ use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::collections::BTreeMap;
 use tokio::sync::mpsc;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::{sse::pop_sse_line, ConversationTurn, LlmClient, LlmResponse, Message, ToolCall};
 
@@ -46,8 +47,6 @@ struct ChatRequest<'a> {
     messages: Vec<OaiMessage>,
     #[serde(skip_serializing_if = "<[_]>::is_empty")]
     tools: &'a [Value],
-    #[serde(skip_serializing_if = "Option::is_none")]
-    parallel_tool_calls: Option<bool>,
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     stream: bool,
 }
@@ -143,10 +142,8 @@ struct OaiStreamFunction {
 #[derive(Debug, Default)]
 struct StreamAccumulator {
     text: String,
-    tool_id: Option<String>,
-    tool_name: Option<String>,
-    tool_arguments: String,
-    tool_block_index: Option<usize>,
+    // key: tool call index, value: (id, name, accumulated_args_json)
+    tools: BTreeMap<usize, (Option<String>, Option<String>, String)>,
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -179,22 +176,22 @@ fn turn_to_oai(turn: &ConversationTurn) -> OaiMessage {
             tool_calls: None,
             tool_call_id: None,
         },
-        ConversationTurn::AssistantToolCall {
-            id,
-            name,
-            arguments,
-            reasoning,
-        } => OaiMessage {
+        ConversationTurn::AssistantToolCall { calls, reasoning } => OaiMessage {
             role: "assistant",
             content: reasoning.clone(),
-            tool_calls: Some(vec![OaiOutboundToolCall {
-                id: id.clone(),
-                kind: "function",
-                function: OaiOutboundFunction {
-                    name: name.clone(),
-                    arguments: arguments.to_string(),
-                },
-            }]),
+            tool_calls: Some(
+                calls
+                    .iter()
+                    .map(|tc| OaiOutboundToolCall {
+                        id: tc.id.clone(),
+                        kind: "function",
+                        function: OaiOutboundFunction {
+                            name: tc.name.clone(),
+                            arguments: tc.arguments.to_string(),
+                        },
+                    })
+                    .collect(),
+            ),
             tool_call_id: None,
         },
         ConversationTurn::ToolResult {
@@ -229,34 +226,21 @@ fn apply_stream_data(
 
         if let Some(tool_calls) = choice.delta.tool_calls {
             for tool_call in tool_calls {
-                // Track and filter by the first tool call's index so parallel
-                // tool calls don't contaminate tool_arguments with a second
-                // call's JSON, which would produce invalid concatenated JSON.
-                if let Some(idx) = tool_call.index {
-                    match accumulator.tool_block_index {
-                        None => accumulator.tool_block_index = Some(idx),
-                        Some(first) if idx != first => {
-                            warn!(
-                                first_index = first,
-                                skipped_index = idx,
-                                "ignoring parallel tool call delta"
-                            );
-                            continue;
-                        }
-                        _ => {}
-                    }
-                } else if accumulator.tool_block_index.is_some() {
-                    // index absent but we already captured a call — treat as belonging to it
-                }
+                let idx = tool_call.index.unwrap_or(0);
+                let entry = accumulator
+                    .tools
+                    .entry(idx)
+                    .or_insert((None, None, String::new()));
+
                 if let Some(id) = tool_call.id {
-                    accumulator.tool_id = Some(id);
+                    entry.0 = Some(id);
                 }
                 if let Some(function) = tool_call.function {
                     if let Some(name) = function.name {
-                        accumulator.tool_name = Some(name);
+                        entry.1 = Some(name);
                     }
                     if let Some(arguments) = function.arguments {
-                        accumulator.tool_arguments.push_str(&arguments);
+                        entry.2.push_str(&arguments);
                     }
                 }
             }
@@ -267,22 +251,25 @@ fn apply_stream_data(
 }
 
 fn accumulated_response(accumulator: StreamAccumulator) -> Result<LlmResponse> {
-    let tool_call = match (accumulator.tool_id, accumulator.tool_name) {
-        (Some(id), Some(name)) => {
-            let arguments = if accumulator.tool_arguments.is_empty() {
-                serde_json::json!({})
-            } else {
-                serde_json::from_str(&accumulator.tool_arguments)
-                    .context("parsing streamed tool call arguments")?
-            };
-            Some(ToolCall {
-                id,
-                name,
-                arguments,
-            })
-        }
-        _ => None,
-    };
+    let tool_calls = accumulator
+        .tools
+        .into_values()
+        .filter_map(|(id, name, args_json)| match (id, name) {
+            (Some(id), Some(name)) => {
+                let arguments = if args_json.is_empty() {
+                    serde_json::json!({})
+                } else {
+                    serde_json::from_str(&args_json).ok()?
+                };
+                Some(ToolCall {
+                    id,
+                    name,
+                    arguments,
+                })
+            }
+            _ => None,
+        })
+        .collect();
 
     let content = if accumulator.text.is_empty() {
         None
@@ -290,7 +277,10 @@ fn accumulated_response(accumulator: StreamAccumulator) -> Result<LlmResponse> {
         Some(accumulator.text)
     };
 
-    Ok(LlmResponse { content, tool_call })
+    Ok(LlmResponse {
+        content,
+        tool_calls,
+    })
 }
 
 #[async_trait]
@@ -306,12 +296,10 @@ impl LlmClient for OpenAiClient {
         // OpenAI expects the system prompt as the first entry in the messages array.
         let messages = build_messages(system, turns);
 
-        let parallel_tool_calls = (!tools.is_empty()).then_some(false);
         let body = ChatRequest {
             model: &self.model,
             messages,
             tools,
-            parallel_tool_calls,
             stream: false,
         };
 
@@ -339,24 +327,31 @@ impl LlmClient for OpenAiClient {
             .context("no choices in OpenAI response")?
             .message;
 
-        if let Some(tool_calls) = msg.tool_calls {
-            if let Some(tc) = tool_calls.into_iter().next() {
-                let args: Value = serde_json::from_str(&tc.function.arguments)
-                    .context("parsing tool call arguments")?;
-                return Ok(LlmResponse {
-                    content: msg.content, // preserve any reasoning alongside the tool call
-                    tool_call: Some(ToolCall {
+        if let Some(raw_calls) = msg.tool_calls {
+            let tool_calls = raw_calls
+                .into_iter()
+                .map(|tc| {
+                    let args: Value = serde_json::from_str(&tc.function.arguments)
+                        .context("parsing tool call arguments")?;
+                    Ok(ToolCall {
                         id: tc.id,
                         name: tc.function.name,
                         arguments: args,
-                    }),
+                    })
+                })
+                .collect::<Result<Vec<_>>>()?;
+
+            if !tool_calls.is_empty() {
+                return Ok(LlmResponse {
+                    content: msg.content,
+                    tool_calls,
                 });
             }
         }
 
         Ok(LlmResponse {
             content: msg.content,
-            tool_call: None,
+            tool_calls: vec![],
         })
     }
 
@@ -370,12 +365,10 @@ impl LlmClient for OpenAiClient {
         debug!(model = %self.model, turns = turns.len(), "calling OpenAI (streaming)");
 
         let messages = build_messages(system, turns);
-        let parallel_tool_calls = (!tools.is_empty()).then_some(false);
         let body = ChatRequest {
             model: &self.model,
             messages,
             tools,
-            parallel_tool_calls,
             stream: true,
         };
 
@@ -453,9 +446,11 @@ mod tests {
     #[test]
     fn assistant_tool_call_serializes_to_tool_calls_array() {
         let turn = ConversationTurn::AssistantToolCall {
-            id: "call_01".to_string(),
-            name: "read".to_string(),
-            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            calls: vec![ToolCall {
+                id: "call_01".to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            }],
             reasoning: None,
         };
         let msg = turn_to_oai(&turn);
@@ -471,6 +466,30 @@ mod tests {
         // arguments must be a JSON string (OpenAI wire format)
         let args: serde_json::Value = serde_json::from_str(&calls[0].function.arguments).unwrap();
         assert_eq!(args["file_path"], "/tmp/a.txt");
+    }
+
+    #[test]
+    fn assistant_parallel_tool_calls_serialize_to_multiple_entries() {
+        let turn = ConversationTurn::AssistantToolCall {
+            calls: vec![
+                ToolCall {
+                    id: "call_01".to_string(),
+                    name: "read".to_string(),
+                    arguments: serde_json::json!({"file_path": "/a"}),
+                },
+                ToolCall {
+                    id: "call_02".to_string(),
+                    name: "list_dir".to_string(),
+                    arguments: serde_json::json!({"dir_path": "/"}),
+                },
+            ],
+            reasoning: None,
+        };
+        let msg = turn_to_oai(&turn);
+        let calls = msg.tool_calls.unwrap();
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].id, "call_01");
+        assert_eq!(calls[1].id, "call_02");
     }
 
     #[test]
@@ -492,15 +511,10 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &[],
-            parallel_tool_calls: None,
             stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_none(), "empty tools must be omitted");
-        assert!(
-            json.get("parallel_tool_calls").is_none(),
-            "parallel_tool_calls must be omitted when None"
-        );
     }
 
     #[test]
@@ -510,12 +524,14 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &tools,
-            parallel_tool_calls: Some(false),
             stream: false,
         };
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("tools").is_some());
-        assert_eq!(json["parallel_tool_calls"], false);
+        assert!(
+            json.get("parallel_tool_calls").is_none(),
+            "parallel_tool_calls must not be set — we let the API default to enabled"
+        );
     }
 
     #[test]
@@ -524,7 +540,6 @@ mod tests {
             model: "gpt-test",
             messages: vec![],
             tools: &[],
-            parallel_tool_calls: None,
             stream: true,
         };
         let json = serde_json::to_value(&req).unwrap();
@@ -553,7 +568,7 @@ mod tests {
         assert_eq!(rx.try_recv().unwrap(), "world");
         let response = accumulated_response(accumulator).unwrap();
         assert_eq!(response.content.as_deref(), Some("hello world"));
-        assert!(response.tool_call.is_none());
+        assert!(response.tool_calls.is_empty());
     }
 
     #[test]
@@ -576,7 +591,8 @@ mod tests {
 
         let response = accumulated_response(accumulator).unwrap();
         assert!(response.content.is_none());
-        let tool_call = response.tool_call.unwrap();
+        assert_eq!(response.tool_calls.len(), 1);
+        let tool_call = &response.tool_calls[0];
         assert_eq!(tool_call.id, "call_01");
         assert_eq!(tool_call.name, "read");
         assert_eq!(tool_call.arguments["file_path"], "/tmp/a.txt");
@@ -598,9 +614,11 @@ mod tests {
     #[test]
     fn tool_call_with_reasoning_sets_content_alongside_tool_calls() {
         let turn = ConversationTurn::AssistantToolCall {
-            id: "call_01".to_string(),
-            name: "read".to_string(),
-            arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            calls: vec![ToolCall {
+                id: "call_01".to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({"file_path": "/tmp/a.txt"}),
+            }],
             reasoning: Some("I should read the file.".to_string()),
         };
         let msg = turn_to_oai(&turn);
@@ -613,9 +631,11 @@ mod tests {
     #[test]
     fn tool_call_without_reasoning_has_no_content() {
         let turn = ConversationTurn::AssistantToolCall {
-            id: "call_02".to_string(),
-            name: "read".to_string(),
-            arguments: serde_json::json!({}),
+            calls: vec![ToolCall {
+                id: "call_02".to_string(),
+                name: "read".to_string(),
+                arguments: serde_json::json!({}),
+            }],
             reasoning: None,
         };
         let msg = turn_to_oai(&turn);
@@ -624,11 +644,11 @@ mod tests {
     }
 
     #[test]
-    fn parallel_tool_calls_in_stream_captures_only_first() {
+    fn parallel_tool_calls_in_stream_captured_correctly() {
         let (tx, _rx) = mpsc::unbounded_channel();
         let mut accumulator = StreamAccumulator::default();
 
-        // First tool call (index 0) — id and name arrive in separate deltas.
+        // First tool call (index 0)
         apply_stream_data(
             r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_01","type":"function","function":{"name":"list_dir","arguments":""}}]}}]}"#,
             &tx,
@@ -642,7 +662,7 @@ mod tests {
         )
         .unwrap();
 
-        // Second tool call (index 1) — must be ignored.
+        // Second tool call (index 1)
         apply_stream_data(
             r#"{"choices":[{"delta":{"tool_calls":[{"index":1,"id":"call_02","type":"function","function":{"name":"read","arguments":""}}]}}]}"#,
             &tx,
@@ -657,12 +677,12 @@ mod tests {
         .unwrap();
 
         let response = accumulated_response(accumulator).unwrap();
-        let tool_call = response.tool_call.unwrap();
-        assert_eq!(tool_call.id, "call_01");
-        assert_eq!(tool_call.name, "list_dir");
-        let args: serde_json::Value =
-            serde_json::from_str(&tool_call.arguments.to_string()).unwrap();
-        assert_eq!(args["dir_path"], "/");
-        assert!(args.get("file_path").is_none());
+        assert_eq!(response.tool_calls.len(), 2);
+        assert_eq!(response.tool_calls[0].id, "call_01");
+        assert_eq!(response.tool_calls[0].name, "list_dir");
+        assert_eq!(response.tool_calls[0].arguments["dir_path"], "/");
+        assert_eq!(response.tool_calls[1].id, "call_02");
+        assert_eq!(response.tool_calls[1].name, "read");
+        assert_eq!(response.tool_calls[1].arguments["file_path"], "/README.md");
     }
 }

--- a/crates/llm/tests/stub_tests.rs
+++ b/crates/llm/tests/stub_tests.rs
@@ -66,18 +66,19 @@ fn message_assistant_sets_role() {
 }
 
 #[test]
-fn llm_response_text_has_content_no_tool_call() {
+fn llm_response_text_has_content_no_tool_calls() {
     let r = LlmResponse::text("answer");
     assert_eq!(r.content.as_deref(), Some("answer"));
-    assert!(r.tool_call.is_none());
+    assert!(r.tool_calls.is_empty());
 }
 
 #[test]
-fn llm_response_tool_has_tool_call_no_content() {
+fn llm_response_tool_has_single_tool_call_no_content() {
     let args = serde_json::json!({"x": 1});
     let r = LlmResponse::tool("call_1", "my_tool", args.clone());
     assert!(r.content.is_none());
-    let tc = r.tool_call.unwrap();
+    assert_eq!(r.tool_calls.len(), 1);
+    let tc = &r.tool_calls[0];
     assert_eq!(tc.id, "call_1");
     assert_eq!(tc.name, "my_tool");
     assert_eq!(tc.arguments, args);
@@ -87,7 +88,7 @@ fn llm_response_tool_has_tool_call_no_content() {
 fn llm_response_neither_is_not_final() {
     let r = LlmResponse {
         content: None,
-        tool_call: None,
+        tool_calls: vec![],
     };
     assert!(!r.is_final_answer());
 }
@@ -133,7 +134,7 @@ fn llm_response_text_serde_round_trip() {
     let json = serde_json::to_string(&r).unwrap();
     let r2: LlmResponse = serde_json::from_str(&json).unwrap();
     assert_eq!(r2.content.as_deref(), Some("the answer"));
-    assert!(r2.tool_call.is_none());
+    assert!(r2.tool_calls.is_empty());
 }
 
 #[test]
@@ -141,7 +142,8 @@ fn llm_response_tool_serde_round_trip() {
     let r = LlmResponse::tool("call_1", "calc", serde_json::json!({"expr": "1+1"}));
     let json = serde_json::to_string(&r).unwrap();
     let r2: LlmResponse = serde_json::from_str(&json).unwrap();
-    let tc = r2.tool_call.unwrap();
+    assert_eq!(r2.tool_calls.len(), 1);
+    let tc = &r2.tool_calls[0];
     assert_eq!(tc.name, "calc");
     assert_eq!(tc.id, "call_1");
 }

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -17,6 +17,15 @@ pub enum Role {
     Tool,
 }
 
+/// A single tool call stored in memory — id, name, and arguments only.
+/// Reasoning is on the parent [`EntryContent::ToolCall`] entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: Value,
+}
+
 /// The content of a memory entry — either plain text, a tool invocation made
 /// by the assistant, or the result returned to the assistant after execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -26,10 +35,9 @@ pub enum EntryContent {
         text: String,
     },
     ToolCall {
-        id: String,
-        name: String,
-        arguments: Value,
-        /// Text emitted by the model before the tool call (e.g. chain-of-thought).
+        /// One or more tool calls from a single LLM turn (parallel tool use).
+        calls: Vec<MemoryToolCall>,
+        /// Text emitted by the model before the tool calls (e.g. chain-of-thought).
         /// Preserved so it can be replayed as part of the same assistant message.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         reasoning: Option<String>,
@@ -154,9 +162,11 @@ mod tests {
         mem.add_entry(
             Role::Assistant,
             EntryContent::ToolCall {
-                id: "call_1".into(),
-                name: "read".into(),
-                arguments: serde_json::json!({ "file_path": "/LICENSE" }),
+                calls: vec![MemoryToolCall {
+                    id: "call_1".into(),
+                    name: "read".into(),
+                    arguments: serde_json::json!({ "file_path": "/LICENSE" }),
+                }],
                 reasoning: None,
             },
         );
@@ -171,7 +181,7 @@ mod tests {
         assert_eq!(mem.len(), 2);
         assert!(matches!(
             &mem.entries()[0].content,
-            EntryContent::ToolCall { id, .. } if id == "call_1"
+            EntryContent::ToolCall { calls, .. } if calls[0].id == "call_1"
         ));
         assert!(matches!(
             &mem.entries()[1].content,


### PR DESCRIPTION
## Summary

Both providers were permanently suppressing parallel tool calls
(`disable_parallel_tool_use: true` / `parallel_tool_calls: false`), which
kept the implementation correct but prevented the model from issuing
independent tool calls in a single turn. This removes those flags and wires
up the full stack to handle parallel calls properly.

`LlmResponse.tool_calls` is now a `Vec` (empty = final answer, N = calls);
`ConversationTurn::AssistantToolCall` carries `calls: Vec<ToolCall>`;
`EntryContent::ToolCall` stores the whole batch as one memory entry.
The Anthropic client merges consecutive `ToolResult` turns into a single
user message (required by the API). The agent loop dispatches all calls
concurrently via `futures::join_all` and stores individual result entries.

Closes #39